### PR TITLE
MenubarFlag: Fix only-on-second-change problem

### DIFF
--- a/Source/MenubarFlag.spoon/init.lua
+++ b/Source/MenubarFlag.spoon/init.lua
@@ -188,6 +188,8 @@ function obj:start()
    hs.keycodes.inputSourceChanged(function()
          self:getLayoutAndDrawIndicators()
    end)
+   -- This solves the problem that the callback would not be called until the second layout change after a restart
+   hs.focus()
    return self
 end
 


### PR DESCRIPTION
Fix the problem that the callback would not be called until the second layout change after a restart. Somehow focusing HS triggers the callback and then it works well afterwards.