### PR TITLE
Seal spoon: various improvements and a new plugin

### DIFF
--- a/Source/Seal.spoon/docs.json
+++ b/Source/Seal.spoon/docs.json
@@ -11,12 +11,12 @@
     ],
     "Variable" : [
       {
-        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
-        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "def" : "Seal.plugin_search_paths",
+        "name" : "plugin_search_paths",
         "stripped_doc" : [
           "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory."
         ],
+        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "notes" : [
 
         ],
@@ -25,18 +25,18 @@
         "returns" : [
 
         ],
-        "name" : "plugin_search_paths",
+        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "parameters" : [
 
         ]
       },
       {
-        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
-        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "def" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "name" : "plugins",
         "stripped_doc" : [
           "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command."
         ],
+        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "notes" : [
 
         ],
@@ -45,7 +45,7 @@
         "returns" : [
 
         ],
-        "name" : "plugins",
+        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "parameters" : [
 
         ]
@@ -54,24 +54,96 @@
     "stripped_doc" : [
 
     ],
-    "type" : "Module",
     "desc" : "Pluggable launch bar",
     "Deprecated" : [
 
     ],
+    "type" : "Module",
     "Constructor" : [
 
     ],
     "doc" : "Pluggable launch bar\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/Seal.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/Seal.spoon.zip)",
     "Method" : [
       {
-        "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
-        "desc" : "Loads a list of Seal plugins",
+        "def" : "Seal:refreshCommandsForPlugin(plugin_name)",
+        "name" : "refreshCommandsForPlugin",
+        "stripped_doc" : [
+          "Refresh the list of commands provided by the given plugin.",
+          ""
+        ],
+        "doc" : "Refresh the list of commands provided by the given plugin.\n\nParameters:\n * plugin_name - the name of the plugin. Should be the name as passed to `loadPlugins()` or `loadPluginFromFile`.\n\nReturns:\n * The Seal object\n\nNotes:\n * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands.",
+        "notes" : [
+          " * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands."
+        ],
+        "signature" : "Seal:refreshCommandsForPlugin(plugin_name)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "desc" : "Refresh the list of commands provided by the given plugin.",
+        "parameters" : [
+          " * plugin_name - the name of the plugin. Should be the name as passed to `loadPlugins()` or `loadPluginFromFile`.",
+          ""
+        ]
+      },
+      {
+        "def" : "Seal:refreshAllCommands()",
+        "name" : "refreshAllCommands",
+        "stripped_doc" : [
+          "Refresh the list of commands provided by all the currently loaded plugins.",
+          ""
+        ],
+        "doc" : "Refresh the list of commands provided by all the currently loaded plugins.\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands.",
+        "notes" : [
+          " * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands."
+        ],
+        "signature" : "Seal:refreshAllCommands()",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "desc" : "Refresh the list of commands provided by all the currently loaded plugins.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "def" : "Seal:loadPluginFromFile(plugin_name, file)",
+        "name" : "loadPluginFromFile",
+        "stripped_doc" : [
+          "Loads a plugin from a given file",
+          ""
+        ],
+        "doc" : "Loads a plugin from a given file\n\nParameters:\n * plugin_name - the name of the plugin, without \"seal_\" at the beginning or \".lua\" at the end\n * file - the file where the plugin code is stored.\n\nReturns:\n * The Seal object if the plugin was successfully loaded, `nil` otherwise\n\nNotes:\n * You should normally use `Seal:loadPlugins()`. This method allows you to load plugins\n   from non-standard locations and is mostly a development interface.\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
+        "notes" : [
+          " * You should normally use `Seal:loadPlugins()`. This method allows you to load plugins",
+          "   from non-standard locations and is mostly a development interface.",
+          " * Some plugins may immediately begin doing background work (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:loadPluginFromFile(plugin_name, file)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object if the plugin was successfully loaded, `nil` otherwise",
+          ""
+        ],
+        "desc" : "Loads a plugin from a given file",
+        "parameters" : [
+          " * plugin_name - the name of the plugin, without \"seal_\" at the beginning or \".lua\" at the end",
+          " * file - the file where the plugin code is stored.",
+          ""
+        ]
+      },
+      {
         "def" : "Seal:loadPlugins(plugins)",
+        "name" : "loadPlugins",
         "stripped_doc" : [
           "Loads a list of Seal plugins",
           ""
         ],
+        "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
         "notes" : [
           " * The plugins live inside the Seal.spoon directory",
           " * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end",
@@ -83,20 +155,20 @@
           " * The Seal object",
           ""
         ],
-        "name" : "loadPlugins",
+        "desc" : "Loads a list of Seal plugins",
         "parameters" : [
           " * plugins - A list containing the names of plugins to load",
           ""
         ]
       },
       {
-        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
-        "desc" : "Binds hotkeys for Seal",
         "def" : "Seal:bindHotkeys(mapping)",
+        "name" : "bindHotkeys",
         "stripped_doc" : [
           "Binds hotkeys for Seal",
           ""
         ],
+        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
         "notes" : [
 
         ],
@@ -105,7 +177,7 @@
         "returns" : [
           " * The Seal object"
         ],
-        "name" : "bindHotkeys",
+        "desc" : "Binds hotkeys for Seal",
         "parameters" : [
           " * mapping - A table containing hotkey modifier\/key details for the following items:",
           "  * show - This will cause Seal's UI to be shown",
@@ -113,13 +185,13 @@
         ]
       },
       {
-        "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
-        "desc" : "Starts Seal",
         "def" : "Seal:start()",
+        "name" : "start",
         "stripped_doc" : [
           "Starts Seal",
           ""
         ],
+        "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
         "notes" : [
 
         ],
@@ -128,20 +200,20 @@
         "returns" : [
           " * The Seal object"
         ],
-        "name" : "start",
+        "desc" : "Starts Seal",
         "parameters" : [
           " * None",
           ""
         ]
       },
       {
-        "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
-        "desc" : "Stops Seal",
         "def" : "Seal:stop()",
+        "name" : "stop",
         "stripped_doc" : [
           "Stops Seal",
           ""
         ],
+        "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
         "notes" : [
           " * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)"
         ],
@@ -151,20 +223,20 @@
           " * The Seal object",
           ""
         ],
-        "name" : "stop",
+        "desc" : "Stops Seal",
         "parameters" : [
           " * None",
           ""
         ]
       },
       {
-        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
-        "desc" : "Shows the Seal UI",
         "def" : "Seal:show()",
+        "name" : "show",
         "stripped_doc" : [
           "Shows the Seal UI",
           ""
         ],
+        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
         "notes" : [
           " * This may be useful if you wish to show Seal in response to something other than its hotkey"
         ],
@@ -174,27 +246,27 @@
           " * None",
           ""
         ],
-        "name" : "show",
+        "desc" : "Shows the Seal UI",
         "parameters" : [
           " * None",
           ""
         ]
       }
     ],
-    "Field" : [
+    "Command" : [
 
     ],
-    "Command" : [
+    "Field" : [
 
     ],
     "items" : [
       {
-        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
-        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "def" : "Seal.plugin_search_paths",
+        "name" : "plugin_search_paths",
         "stripped_doc" : [
           "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory."
         ],
+        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "notes" : [
 
         ],
@@ -203,18 +275,18 @@
         "returns" : [
 
         ],
-        "name" : "plugin_search_paths",
+        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
         "parameters" : [
 
         ]
       },
       {
-        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
-        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "def" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "name" : "plugins",
         "stripped_doc" : [
           "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command."
         ],
+        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "notes" : [
 
         ],
@@ -223,19 +295,19 @@
         "returns" : [
 
         ],
-        "name" : "plugins",
+        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
         "parameters" : [
 
         ]
       },
       {
-        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
-        "desc" : "Binds hotkeys for Seal",
         "def" : "Seal:bindHotkeys(mapping)",
+        "name" : "bindHotkeys",
         "stripped_doc" : [
           "Binds hotkeys for Seal",
           ""
         ],
+        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
         "notes" : [
 
         ],
@@ -244,7 +316,7 @@
         "returns" : [
           " * The Seal object"
         ],
-        "name" : "bindHotkeys",
+        "desc" : "Binds hotkeys for Seal",
         "parameters" : [
           " * mapping - A table containing hotkey modifier\/key details for the following items:",
           "  * show - This will cause Seal's UI to be shown",
@@ -252,13 +324,39 @@
         ]
       },
       {
-        "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
-        "desc" : "Loads a list of Seal plugins",
+        "def" : "Seal:loadPluginFromFile(plugin_name, file)",
+        "name" : "loadPluginFromFile",
+        "stripped_doc" : [
+          "Loads a plugin from a given file",
+          ""
+        ],
+        "doc" : "Loads a plugin from a given file\n\nParameters:\n * plugin_name - the name of the plugin, without \"seal_\" at the beginning or \".lua\" at the end\n * file - the file where the plugin code is stored.\n\nReturns:\n * The Seal object if the plugin was successfully loaded, `nil` otherwise\n\nNotes:\n * You should normally use `Seal:loadPlugins()`. This method allows you to load plugins\n   from non-standard locations and is mostly a development interface.\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
+        "notes" : [
+          " * You should normally use `Seal:loadPlugins()`. This method allows you to load plugins",
+          "   from non-standard locations and is mostly a development interface.",
+          " * Some plugins may immediately begin doing background work (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:loadPluginFromFile(plugin_name, file)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object if the plugin was successfully loaded, `nil` otherwise",
+          ""
+        ],
+        "desc" : "Loads a plugin from a given file",
+        "parameters" : [
+          " * plugin_name - the name of the plugin, without \"seal_\" at the beginning or \".lua\" at the end",
+          " * file - the file where the plugin code is stored.",
+          ""
+        ]
+      },
+      {
         "def" : "Seal:loadPlugins(plugins)",
+        "name" : "loadPlugins",
         "stripped_doc" : [
           "Loads a list of Seal plugins",
           ""
         ],
+        "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
         "notes" : [
           " * The plugins live inside the Seal.spoon directory",
           " * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end",
@@ -270,20 +368,66 @@
           " * The Seal object",
           ""
         ],
-        "name" : "loadPlugins",
+        "desc" : "Loads a list of Seal plugins",
         "parameters" : [
           " * plugins - A list containing the names of plugins to load",
           ""
         ]
       },
       {
-        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
-        "desc" : "Shows the Seal UI",
+        "def" : "Seal:refreshAllCommands()",
+        "name" : "refreshAllCommands",
+        "stripped_doc" : [
+          "Refresh the list of commands provided by all the currently loaded plugins.",
+          ""
+        ],
+        "doc" : "Refresh the list of commands provided by all the currently loaded plugins.\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands.",
+        "notes" : [
+          " * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands."
+        ],
+        "signature" : "Seal:refreshAllCommands()",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "desc" : "Refresh the list of commands provided by all the currently loaded plugins.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "def" : "Seal:refreshCommandsForPlugin(plugin_name)",
+        "name" : "refreshCommandsForPlugin",
+        "stripped_doc" : [
+          "Refresh the list of commands provided by the given plugin.",
+          ""
+        ],
+        "doc" : "Refresh the list of commands provided by the given plugin.\n\nParameters:\n * plugin_name - the name of the plugin. Should be the name as passed to `loadPlugins()` or `loadPluginFromFile`.\n\nReturns:\n * The Seal object\n\nNotes:\n * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands.",
+        "notes" : [
+          " * Most Seal plugins expose a static list of commands (if any), which are registered at the time the plugin is loaded. This method is used for plugins which expose a dynamic or changing (e.g. depending on configuration) list of commands."
+        ],
+        "signature" : "Seal:refreshCommandsForPlugin(plugin_name)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "desc" : "Refresh the list of commands provided by the given plugin.",
+        "parameters" : [
+          " * plugin_name - the name of the plugin. Should be the name as passed to `loadPlugins()` or `loadPluginFromFile`.",
+          ""
+        ]
+      },
+      {
         "def" : "Seal:show()",
+        "name" : "show",
         "stripped_doc" : [
           "Shows the Seal UI",
           ""
         ],
+        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
         "notes" : [
           " * This may be useful if you wish to show Seal in response to something other than its hotkey"
         ],
@@ -293,20 +437,20 @@
           " * None",
           ""
         ],
-        "name" : "show",
+        "desc" : "Shows the Seal UI",
         "parameters" : [
           " * None",
           ""
         ]
       },
       {
-        "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
-        "desc" : "Starts Seal",
         "def" : "Seal:start()",
+        "name" : "start",
         "stripped_doc" : [
           "Starts Seal",
           ""
         ],
+        "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
         "notes" : [
 
         ],
@@ -315,20 +459,20 @@
         "returns" : [
           " * The Seal object"
         ],
-        "name" : "start",
+        "desc" : "Starts Seal",
         "parameters" : [
           " * None",
           ""
         ]
       },
       {
-        "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
-        "desc" : "Stops Seal",
         "def" : "Seal:stop()",
+        "name" : "stop",
         "stripped_doc" : [
           "Stops Seal",
           ""
         ],
+        "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
         "notes" : [
           " * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)"
         ],
@@ -338,7 +482,7 @@
           " * The Seal object",
           ""
         ],
-        "name" : "stop",
+        "desc" : "Stops Seal",
         "parameters" : [
           " * None",
           ""

--- a/Source/Seal.spoon/docs.json
+++ b/Source/Seal.spoon/docs.json
@@ -1,39 +1,350 @@
 [
   {
-    "doc" : "Pluggable launch bar",
-    "items" : [
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
       {
-        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
-        "type" : "Method",
-        "name" : "bindHotkeys",
-        "def" : "Seal:bindHotkeys(mapping)"
+        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
+        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
+        "def" : "Seal.plugin_search_paths",
+        "stripped_doc" : [
+          "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal.plugin_search_paths",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "plugin_search_paths",
+        "parameters" : [
+
+        ]
       },
+      {
+        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
+        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
+        "def" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "stripped_doc" : [
+          "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "plugins",
+        "parameters" : [
+
+        ]
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "type" : "Module",
+    "desc" : "Pluggable launch bar",
+    "Deprecated" : [
+
+    ],
+    "Constructor" : [
+
+    ],
+    "doc" : "Pluggable launch bar\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/Seal.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/Seal.spoon.zip)",
+    "Method" : [
       {
         "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
+        "desc" : "Loads a list of Seal plugins",
+        "def" : "Seal:loadPlugins(plugins)",
+        "stripped_doc" : [
+          "Loads a list of Seal plugins",
+          ""
+        ],
+        "notes" : [
+          " * The plugins live inside the Seal.spoon directory",
+          " * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end",
+          " * Some plugins may immediately begin doing background work (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:loadPlugins(plugins)",
         "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
         "name" : "loadPlugins",
-        "def" : "Seal:loadPlugins(plugins)"
+        "parameters" : [
+          " * plugins - A list containing the names of plugins to load",
+          ""
+        ]
       },
       {
-        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
+        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
+        "desc" : "Binds hotkeys for Seal",
+        "def" : "Seal:bindHotkeys(mapping)",
+        "stripped_doc" : [
+          "Binds hotkeys for Seal",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal:bindHotkeys(mapping)",
         "type" : "Method",
-        "name" : "show",
-        "def" : "Seal:show()"
+        "returns" : [
+          " * The Seal object"
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing hotkey modifier\/key details for the following items:",
+          "  * show - This will cause Seal's UI to be shown",
+          ""
+        ]
       },
       {
         "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
+        "desc" : "Starts Seal",
+        "def" : "Seal:start()",
+        "stripped_doc" : [
+          "Starts Seal",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal:start()",
         "type" : "Method",
+        "returns" : [
+          " * The Seal object"
+        ],
         "name" : "start",
-        "def" : "Seal:start()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
         "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
+        "desc" : "Stops Seal",
+        "def" : "Seal:stop()",
+        "stripped_doc" : [
+          "Stops Seal",
+          ""
+        ],
+        "notes" : [
+          " * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:stop()",
         "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
         "name" : "stop",
-        "def" : "Seal:stop()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
+        "desc" : "Shows the Seal UI",
+        "def" : "Seal:show()",
+        "stripped_doc" : [
+          "Shows the Seal UI",
+          ""
+        ],
+        "notes" : [
+          " * This may be useful if you wish to show Seal in response to something other than its hotkey"
+        ],
+        "signature" : "Seal:show()",
+        "type" : "Method",
+        "returns" : [
+          " * None",
+          ""
+        ],
+        "name" : "show",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       }
     ],
-    "name" : "Seal",
-    "desc" : "Pluggable launch bar"
+    "Field" : [
+
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
+        "desc" : "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory.",
+        "def" : "Seal.plugin_search_paths",
+        "stripped_doc" : [
+          "List of directories where Seal will look for plugins. Defaults to `~\/.hammerspoon\/seal_plugins\/` and the Seal Spoon directory."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal.plugin_search_paths",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "plugin_search_paths",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
+        "desc" : "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command.",
+        "def" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "stripped_doc" : [
+          "If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `\/usr\/bin\/open` command."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal.plugins.safari_bookmarks.always_open_with_safari",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "plugins",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Binds hotkeys for Seal\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause Seal's UI to be shown\n\nReturns:\n * The Seal object",
+        "desc" : "Binds hotkeys for Seal",
+        "def" : "Seal:bindHotkeys(mapping)",
+        "stripped_doc" : [
+          "Binds hotkeys for Seal",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object"
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing hotkey modifier\/key details for the following items:",
+          "  * show - This will cause Seal's UI to be shown",
+          ""
+        ]
+      },
+      {
+        "doc" : "Loads a list of Seal plugins\n\nParameters:\n * plugins - A list containing the names of plugins to load\n\nReturns:\n * The Seal object\n\nNotes:\n * The plugins live inside the Seal.spoon directory\n * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end\n * Some plugins may immediately begin doing background work (e.g. Spotlight searches)",
+        "desc" : "Loads a list of Seal plugins",
+        "def" : "Seal:loadPlugins(plugins)",
+        "stripped_doc" : [
+          "Loads a list of Seal plugins",
+          ""
+        ],
+        "notes" : [
+          " * The plugins live inside the Seal.spoon directory",
+          " * The plugin names in the list, should not have `seal_` at the start, or `.lua` at the end",
+          " * Some plugins may immediately begin doing background work (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:loadPlugins(plugins)",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "name" : "loadPlugins",
+        "parameters" : [
+          " * plugins - A list containing the names of plugins to load",
+          ""
+        ]
+      },
+      {
+        "doc" : "Shows the Seal UI\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This may be useful if you wish to show Seal in response to something other than its hotkey",
+        "desc" : "Shows the Seal UI",
+        "def" : "Seal:show()",
+        "stripped_doc" : [
+          "Shows the Seal UI",
+          ""
+        ],
+        "notes" : [
+          " * This may be useful if you wish to show Seal in response to something other than its hotkey"
+        ],
+        "signature" : "Seal:show()",
+        "type" : "Method",
+        "returns" : [
+          " * None",
+          ""
+        ],
+        "name" : "show",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "doc" : "Starts Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object",
+        "desc" : "Starts Seal",
+        "def" : "Seal:start()",
+        "stripped_doc" : [
+          "Starts Seal",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "Seal:start()",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object"
+        ],
+        "name" : "start",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      },
+      {
+        "doc" : "Stops Seal\n\nParameters:\n * None\n\nReturns:\n * The Seal object\n\nNotes:\n * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)",
+        "desc" : "Stops Seal",
+        "def" : "Seal:stop()",
+        "stripped_doc" : [
+          "Stops Seal",
+          ""
+        ],
+        "notes" : [
+          " * Some Seal plugins will continue performing background work even after this call (e.g. Spotlight searches)"
+        ],
+        "signature" : "Seal:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * The Seal object",
+          ""
+        ],
+        "name" : "stop",
+        "parameters" : [
+          " * None",
+          ""
+        ]
+      }
+    ],
+    "name" : "Seal"
   }
 ]

--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -50,7 +50,7 @@ function obj:loadPlugins(plugins)
         print("-- Loading Seal plugin: " .. plugin_name)
         plugin = dofile(self.spoonPath.."/seal_"..plugin_name..".lua")
         plugin.seal = self
-        table.insert(obj.plugins, plugin)
+        obj.plugins[plugin_name] = plugin
         for cmd,cmdInfo in pairs(plugin:commands()) do
             print("-- Adding Seal command: "..cmd)
             obj.commands[cmd] = cmdInfo

--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -49,15 +49,17 @@ function obj:loadPlugins(plugins)
     for k,plugin_name in pairs(plugins) do
        print("-- Loading Seal plugin: " .. plugin_name)
        for _,dir in ipairs(self.plugin_search_paths) do
-          local file = dir .. "/seal_" .. plugin_name .. ".lua"
-          local f = loadfile(file)
-          if f~= nil then
-             plugin = f()
-             plugin.seal = self
-             obj.plugins[plugin_name] = plugin
-             for cmd,cmdInfo in pairs(plugin:commands()) do
-                print("-- Adding Seal command: "..cmd)
-                obj.commands[cmd] = cmdInfo
+          if obj.plugins[plugin_name] == nil then
+             local file = dir .. "/seal_" .. plugin_name .. ".lua"
+             local f = loadfile(file)
+             if f~= nil then
+                plugin = f()
+                plugin.seal = self
+                obj.plugins[plugin_name] = plugin
+                for cmd,cmdInfo in pairs(plugin:commands()) do
+                   print("-- Adding Seal command: "..cmd)
+                   obj.commands[cmd] = cmdInfo
+                end
              end
           end
        end

--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -20,12 +20,12 @@ obj.plugins = {}
 obj.commands = {}
 obj.queryChangedTimer = nil
 
--- Internal function used to find our location, so we know where to load plugins from
-local function script_path()
-    local str = debug.getinfo(2, "S").source:sub(2)
-    return str:match("(.*/)")
-end
-obj.spoonPath = script_path()
+obj.spoonPath = hs.spoons.script_path()
+
+--- Seal.plugin_search_paths
+--- Variable
+--- List of directories where Seal will look for plugins. Defaults to `~/.hammerspoon/seal_plugins/` and the Seal Spoon directory.
+obj.plugin_search_paths = { hs.configdir .. "/seal_plugins", obj.spoonPath }
 
 --- Seal:loadPlugins(plugins)
 --- Method
@@ -47,14 +47,20 @@ function obj:loadPlugins(plugins)
     self.chooser:queryChangedCallback(self.queryChangedCallback)
 
     for k,plugin_name in pairs(plugins) do
-        print("-- Loading Seal plugin: " .. plugin_name)
-        plugin = dofile(self.spoonPath.."/seal_"..plugin_name..".lua")
-        plugin.seal = self
-        obj.plugins[plugin_name] = plugin
-        for cmd,cmdInfo in pairs(plugin:commands()) do
-            print("-- Adding Seal command: "..cmd)
-            obj.commands[cmd] = cmdInfo
-        end
+       print("-- Loading Seal plugin: " .. plugin_name)
+       for _,dir in ipairs(self.plugin_search_paths) do
+          local file = dir .. "/seal_" .. plugin_name .. ".lua"
+          local f = loadfile(file)
+          if f~= nil then
+             plugin = f()
+             plugin.seal = self
+             obj.plugins[plugin_name] = plugin
+             for cmd,cmdInfo in pairs(plugin:commands()) do
+                print("-- Adding Seal command: "..cmd)
+                obj.commands[cmd] = cmdInfo
+             end
+          end
+       end
     end
     return self
 end

--- a/Source/Seal.spoon/seal_apps.lua
+++ b/Source/Seal.spoon/seal_apps.lua
@@ -157,7 +157,7 @@ end
 
 function obj.completionCallback(rowInfo)
    if rowInfo["type"] == "launchOrFocus" then
-      hs.open(rowInfo["path"])
+      hs.execute(string.format("/usr/bin/open '%s'", rowInfo["path"]))
    elseif rowInfo["type"] == "kill" then
       hs.application.get(rowInfo["pid"]):kill()
    elseif rowInfo["type"] == "reveal" then

--- a/Source/Seal.spoon/seal_safari_bookmarks.lua
+++ b/Source/Seal.spoon/seal_safari_bookmarks.lua
@@ -4,6 +4,11 @@ obj.__name = "seal_safari_bookmarks"
 obj.bookmarkCache = {}
 obj.icon = hs.image.iconForFileType("com.apple.safari.bookmark")
 
+--- Seal.plugins.safari_bookmarks.always_open_with_safari
+--- Variable
+--- If `true` (default), bookmarks are always opened with Safari, otherwise they are opened with the default application using the `/usr/bin/open` command.
+obj.always_open_with_safari = true
+
 local modifyNameMap = function(info, add)
     for _, item in ipairs(info) do
         if add then
@@ -67,9 +72,13 @@ function obj.choicesBookmarks(query)
 end
 
 function obj.completionCallback(rowInfo)
-    if rowInfo["type"] == "openURL" then
-        hs.urlevent.openURLWithBundle(rowInfo["url"], "com.apple.Safari")
-    end
+   if rowInfo["type"] == "openURL" then
+      if obj.always_open_with_safari then
+         hs.urlevent.openURLWithBundle(rowInfo["url"], "com.apple.Safari")
+      else
+         hs.execute(string.format("/usr/bin/open '%s'", rowInfo["url"]))
+      end
+   end
 end
 
 return obj

--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -15,11 +15,42 @@ obj.default_icon = hs.image.imageFromName(hs.image.systemImageNames.ActionTempla
 --- A table containing the definitions of static user-defined actions. Each entry is indexed by the name of the entry as it will be shown in the chooser. Its value is a table which can have the following keys (one of `fn` or `url` is required. If both are provided, `url` is ignored):
 ---  * fn - A function which will be called when the entry is selected. The function receives no arguments.
 ---  * url - A URL which will be opened when the entry is selected. Can also be non-HTTP URLs, such as `mailto:` or other app-specific URLs.
----  * icon - (optional) An `hs.image` object that will be shown next to the entry in the chooser. If not provided, `Seal.plugins.useractions.default_icon` is used.
+---  * icon - (optional) An `hs.image` object that will be shown next to the entry in the chooser. If not provided, `Seal.plugins.useractions.default_icon` is used. For `url` bookmarks, it can be set to `"favicon"` to fetch and use the website's favicon.
 ---  * keyword - (optional) A command by which this action will be invoked, effectively turning it into a Seal command. Any arguments passed to the command will be handled as follows:
 ---    * For `fn` actions, passed as an argument to the function
 ---    * For `url` actions, substituted into the URL, taking the place of any occurrences of `${query}`.
 ---  * hotkey - (optional) A hotkey specification in the form `{ modifiers, key }` by which this action can be invoked.
+---
+--- Example configuration:
+--- ```
+--- spoon.Seal:loadPlugins({"useractions"})
+--- spoon.Seal.plugins.useractions.actions =
+---    {
+---       ["Hammerspoon docs webpage"] = {
+---          url = "http://hammerspoon.org/docs/",
+---          icon = hs.image.imageFromName(hs.image.systemImageNames.ApplicationIcon),
+---          hotkey = { hyper, "h" }
+---       },
+---       ["Leave corpnet"] = {
+---          fn = function()
+---             spoon.WiFiTransitions:processTransition('foo', 'corpnet01')
+---          end,
+---       },
+---       ["Arrive in corpnet"] = {
+---          fn = function()
+---             spoon.WiFiTransitions:processTransition('corpnet01', 'foo')
+---          end,
+---       },
+---       ["Translate using Leo"] = {
+---          url = "http://dict.leo.org/ende/index_de.html#/search=${query}",
+---          icon = 'favicon',
+---          keyword = "leo",
+---       },
+---       ["Tell me something"] = {
+---          keyword = "tellme",
+---          fn = function(str) hs.alert.show(str) end,
+---       }
+--- ```
 obj.actions = {}
 
 --- Seal.plugins.useractions.get_favicon

--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -1,0 +1,246 @@
+--- ==== seal_useractions Seal plugin ====
+---
+--- Allow accessing user-defined bookmarks and arbitrary actions from Seal.
+---
+
+local obj = {}
+obj.__index = obj
+obj.__basename = "useractions"
+obj.__name = "seal_" .. obj.__basename
+obj.default_icon = hs.image.imageFromName(hs.image.systemImageNames.ActionTemplate)
+
+--- Seal.plugins.useractions.actions
+--- Variable
+---
+--- A table containing the definitions of static user-defined actions. Each entry is indexed by the name of the entry as it will be shown in the chooser. Its value is a table which can have the following keys (one of `fn` or `url` is required. If both are provided, `url` is ignored):
+---  * fn - A function which will be called when the entry is selected. The function receives no arguments.
+---  * url - A URL which will be opened when the entry is selected. Can also be non-HTTP URLs, such as `mailto:` or other app-specific URLs.
+---  * icon - (optional) An `hs.image` object that will be shown next to the entry in the chooser. If not provided, `Seal.plugins.useractions.default_icon` is used.
+---  * keyword - (optional) A command by which this action will be invoked, effectively turning it into a Seal command. Any arguments passed to the command will be handled as follows:
+---    * For `fn` actions, passed as an argument to the function
+---    * For `url` actions, substituted into the URL, taking the place of any occurrences of `${query}`.
+---  * hotkey - (optional) A hotkey specification in the form `{ modifiers, key }` by which this action can be invoked.
+obj.actions = {}
+
+--- Seal.plugins.useractions.get_favicon
+--- Variable
+---
+--- If `true`, attempt to obtain the favicon for URLs added through the `add` command, and use it in the chooser.
+obj.get_favicon = true
+
+-- Internal functions for storing/retrieving bookmarks in the settings database.
+local getSetting = function(label, default) return hs.settings.get(obj.__name.."."..label) or default end
+local setSetting = function(label, value)   hs.settings.set(obj.__name.."."..label, value); return value end
+
+-- Internal variable where the dynamically-added bookmarks are kept
+obj.stored_actions = getSetting('stored_actions', {})
+
+-- Internal variable where the merged list of bookmarks/actions is kept
+obj.all_actions = nil
+
+function update_all_actions()
+   if (obj.all_actions == nil) then
+      obj.all_actions = {}
+      for k,v in pairs(obj.actions) do obj.all_actions[k] = v end
+      for k,v in pairs(obj.stored_actions) do
+         obj.all_actions[k] = v
+         if v.encoded_icon then
+            v.icon = hs.image.imageFromURL(v.encoded_icon)
+         end
+      end
+   end
+end
+
+function obj:commands()
+   local cmds={
+      add = {
+         cmd = "add",
+         fn = obj.choicesAddURLCommand,
+         name = "Add URL",
+         description = "Add URL to bookmarks",
+         plugin = obj.__name
+      },
+      del = {
+         cmd = "del",
+         fn = obj.choicesDelURLCommand,
+         name = "Delete URL",
+         description = "Delete URL from bookmarks",
+         plugin = obj.__name
+      }
+   }
+   local hotkeys_def = {}
+   local hotkeys_map = {}
+   local any_hotkeys = false
+   for k,v in pairs(self.actions or {}) do
+      if v.keyword and (not cmds[v.keyword]) then
+         if v.url ~= nil and v.icon == 'favicon' then
+            v.icon = obj.favIcon(v.url)
+         end
+         cmds[v.keyword] = {
+            cmd = v.keyword,
+            fn = hs.fnutils.partial(obj.choicesActionKeyword, k, v),
+            name = k,
+            icon = v.icon,
+            plugin = obj.__name
+         }
+      end
+      if v.hotkey then
+         local choice = obj.buildChoice(k,v)
+         hotkeys_def[k] = hs.fnutils.partial(obj.completionCallback, choice)
+         hotkeys_map[k] = v.hotkey
+         hs.printf("def=%s, map=%s", hs.inspect(hotkeys_def), hs.inspect(hotkeys_map))
+         any_hotkeys = true
+      end
+   end
+   if any_hotkeys then
+      hs.spoons.bindHotkeysToSpec(hotkeys_def, hotkeys_map)
+   end
+   return cmds
+end
+
+function obj:bare()
+   return self.bareActions
+end
+
+function obj.buildChoice(action, v)
+   local icon, kind
+   local choice=nil
+   if type(v) == 'table' and v.keyword == nil then
+      if v.fn then
+         kind = 'runFunction'
+      elseif v.url then
+         kind = 'openURL'
+         if v.icon == 'favicon' then
+            v.icon = obj.favIcon(v.url)
+         end
+      end
+      icon = v.icon or obj.default_icon
+      choice = {}
+      choice.text = action
+      choice.type = kind
+      choice.plugin = obj.__name
+      choice.image = icon
+   end
+   return choice
+end
+
+function obj.bareActions(query)
+   local choices = {}
+   if query == nil or query == "" then
+      return choices
+   end
+
+   update_all_actions()
+   obj.seal:refreshCommandsForPlugin(obj.__basename)
+
+   for action,v in pairs(obj.all_actions) do
+      if string.match(action:lower(), query:lower()) then
+         local choice = obj.buildChoice(action, v)
+         if choice then
+            table.insert(choices, choice)
+         end
+      end
+   end
+
+   return choices
+end
+
+function obj.favIcon(url)
+   local query=string.format("http://www.google.com/s2/favicons?domain_url=%s", hs.http.encodeForQuery(url))
+   return hs.image.imageFromURL(query)
+end
+
+function obj.choicesAddURLCommand(query)
+   local choices = {}
+   if query == ".*" then
+      query = "<url> <name>"
+   end
+   local url,name = string.match(query, "([^%s]+)%s+(.*)")
+   local subtext = ""
+   if url then
+      subtext = string.format("New bookmark '%s' pointing to %s", name,url)
+   end
+   local choice = {
+      text = "add " .. query,
+      subText = subtext,
+      url = url,
+      name = name,
+      plugin = obj.__name,
+      type = 'addURL',
+   }
+   table.insert(choices, choice)
+   return choices
+end
+
+function obj.choicesDelURLCommand(query)
+   local choices = {}
+   for k,v in pairs(obj.stored_actions) do
+      if string.match(k:lower(), query:lower()) or string.match(v.url:lower(), query:lower()) then
+         local choice = {
+            text = string.format("delete '%s'", k),
+            subText = v.url,
+            delKey = k,
+            plugin = obj.__name,
+            type = 'delURL',
+         }
+         if v.encoded_icon then
+            choice.image = hs.image.imageFromURL(v.encoded_icon)
+         end
+         table.insert(choices, choice)
+      end
+   end
+   return choices
+end
+
+function obj.choicesActionKeyword(action, def, query)
+   local choices = {}
+   local choice = {
+      text = def.keyword .. " " .. query,
+      subText = action,
+      actionname = action,
+      arg = query,
+      plugin = obj.__name,
+      image = def.icon,
+      type = 'invokeKeyword',
+   }
+   table.insert(choices, choice)
+   return choices
+end
+
+function obj.openURL(url)
+   hs.execute(string.format("/usr/bin/open '%s'", url))
+end
+
+function obj.completionCallback(row)
+   update_all_actions()
+   if row.type == 'runFunction' then
+      local fn = obj.all_actions[row.text].fn
+      fn()
+   elseif row.type == 'openURL' then
+      local url = obj.all_actions[row.text].url
+      obj.openURL(url)
+   elseif row.type == 'addURL' then
+      obj.stored_actions[row.name] = { url = row.url }
+      obj.all_actions = nil
+      if obj.get_favicon then
+         local ico=obj.favIcon(row.url)
+         if ico then
+            obj.stored_actions[row.name]['encoded_icon'] = ico:encodeAsURLString()
+         end
+      end
+      setSetting('stored_actions', obj.stored_actions)
+   elseif row.type == 'delURL' then
+      obj.stored_actions[row.delKey] = nil
+      obj.all_actions = nil
+      setSetting('stored_actions', obj.stored_actions)
+   elseif row.type == 'invokeKeyword' then
+      if obj.actions[row.actionname].fn then
+         obj.actions[row.actionname].fn(row.arg)
+      elseif obj.actions[row.actionname].url then
+         local url = string.gsub(obj.actions[row.actionname].url, '${query}', row.arg)
+         obj.openURL(url)
+      end
+   end
+end
+
+return obj


### PR DESCRIPTION
Several small improvements for Seal, including:
- Allow setting plugin config variables
- Allow a plugin load path
- Use hs.spoons
- Allow seal_safari_bookmarks to open bookmarks using the default browser instead of Safari (configurable).
- Added the following new methods: 
  - `loadPluginFromFile()` allows loading Seal plugins from files outside the regular load paths.
  - `refreshCommandsForPlugin()` and `refreshAllCommands()` allow for dynamic commands to be provided by plugins.

Also includes various improvements to seal_apps plugin:

- Preference panes now appear and open correctly in Seal.
- Added "reveal" command to reveal an application in the Finder
- Added icons to the "kill" command listing.

Finally, a brand new Seal plugin 'useractions', which allows accessing user-defined bookmarks and arbitrary actions from Seal. User actions can be defined statically, and bookmarks can also be added/removed dynamically using the `add` and `del` commands. Bookmarks and functions can also be parameterized and defined as commands, or have hotkeys associated with them.