### PR TITLE
MenubarFlag: various fixes

### DIFF
--- a/Source/MenubarFlag.spoon/docs.json
+++ b/Source/MenubarFlag.spoon/docs.json
@@ -12,13 +12,13 @@
     "Variable" : [
       {
         "doc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
         ],
-        "name" : "allScreens",
+        "def" : "MenubarFlag.allScreens",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -27,18 +27,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.allScreens",
+        "name" : "allScreens",
         "desc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
       },
       {
         "doc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
         ],
-        "name" : "indicatorHeight",
+        "def" : "MenubarFlag.indicatorHeight",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -47,18 +47,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorHeight",
+        "name" : "indicatorHeight",
         "desc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
       },
       {
         "doc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
         ],
-        "name" : "indicatorAlpha",
+        "def" : "MenubarFlag.indicatorAlpha",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -67,18 +67,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorAlpha",
+        "name" : "indicatorAlpha",
         "desc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
       },
       {
         "doc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
         ],
-        "name" : "indicatorInAllSpaces",
+        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -87,14 +87,11 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "name" : "indicatorInAllSpaces",
         "desc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
       },
       {
         "doc" : "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Table that contains the configuration of indicator colors",
           "",
@@ -131,7 +128,10 @@
           "```",
           "Contributions of indicator specs are welcome!"
         ],
-        "name" : "colors",
+        "def" : "MenubarFlag.colors",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -140,34 +140,36 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.colors",
+        "name" : "colors",
         "desc" : "Table that contains the configuration of indicator colors"
       }
     ],
     "stripped_doc" : [
 
     ],
-    "desc" : "Color the menubar according to the current keyboard layout",
     "Deprecated" : [
 
     ],
     "type" : "Module",
+    "desc" : "Color the menubar according to the current keyboard layout",
     "Constructor" : [
 
     ],
-    "doc" : "Color the menubar according to the current keyboard layout\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https:\/\/pqrs.org\/osx\/ShowyEdge\/index.html.en)",
+    "Field" : [
+
+    ],
     "Method" : [
       {
         "doc" : "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
-        "parameters" : [
-          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
-          ""
-        ],
         "stripped_doc" : [
           "Draw the indicators corresponding to the given layout name",
           ""
         ],
-        "name" : "drawIndicators",
+        "def" : "MenubarFlag:drawIndicators(src)",
+        "parameters" : [
+          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
+          ""
+        ],
         "notes" : [
 
         ],
@@ -176,20 +178,20 @@
         "returns" : [
           " * The MenubarFlag object"
         ],
-        "def" : "MenubarFlag:drawIndicators(src)",
+        "name" : "drawIndicators",
         "desc" : "Draw the indicators corresponding to the given layout name"
       },
       {
         "doc" : "Draw indicators for the current keyboard method or layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
-        "parameters" : [
-          " * None",
-          ""
-        ],
         "stripped_doc" : [
           "Draw indicators for the current keyboard method or layout",
           ""
         ],
-        "name" : "getLayoutAndDrawindicators",
+        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "parameters" : [
+          " * None",
+          ""
+        ],
         "notes" : [
 
         ],
@@ -198,18 +200,18 @@
         "returns" : [
           " * The MenubarFlag object"
         ],
-        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "name" : "getLayoutAndDrawindicators",
         "desc" : "Draw indicators for the current keyboard method or layout"
       },
       {
         "doc" : "Start the keyboard layout watcher to draw the menubar indicators.",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Start the keyboard layout watcher to draw the menubar indicators."
         ],
-        "name" : "start",
+        "def" : "MenubarFlag:start()",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -218,18 +220,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag:start()",
+        "name" : "start",
         "desc" : "Start the keyboard layout watcher to draw the menubar indicators."
       },
       {
         "doc" : "Remove indicators and stop the keyboard layout watcher",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Remove indicators and stop the keyboard layout watcher"
         ],
-        "name" : "stop",
+        "def" : "MenubarFlag:stop()",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -238,26 +240,21 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag:stop()",
+        "name" : "stop",
         "desc" : "Remove indicators and stop the keyboard layout watcher"
       }
     ],
-    "Field" : [
-
-    ],
-    "Command" : [
-
-    ],
+    "doc" : "Color the menubar according to the current keyboard layout\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https:\/\/pqrs.org\/osx\/ShowyEdge\/index.html.en)",
     "items" : [
       {
         "doc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
         ],
-        "name" : "allScreens",
+        "def" : "MenubarFlag.allScreens",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -266,14 +263,11 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.allScreens",
+        "name" : "allScreens",
         "desc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
       },
       {
         "doc" : "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Table that contains the configuration of indicator colors",
           "",
@@ -310,7 +304,10 @@
           "```",
           "Contributions of indicator specs are welcome!"
         ],
-        "name" : "colors",
+        "def" : "MenubarFlag.colors",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -319,18 +316,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.colors",
+        "name" : "colors",
         "desc" : "Table that contains the configuration of indicator colors"
       },
       {
         "doc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
         ],
-        "name" : "indicatorAlpha",
+        "def" : "MenubarFlag.indicatorAlpha",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -339,18 +336,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorAlpha",
+        "name" : "indicatorAlpha",
         "desc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
       },
       {
         "doc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
         ],
-        "name" : "indicatorHeight",
+        "def" : "MenubarFlag.indicatorHeight",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -359,18 +356,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorHeight",
+        "name" : "indicatorHeight",
         "desc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
       },
       {
         "doc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
         ],
-        "name" : "indicatorInAllSpaces",
+        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -379,20 +376,20 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "name" : "indicatorInAllSpaces",
         "desc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
       },
       {
         "doc" : "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
-        "parameters" : [
-          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
-          ""
-        ],
         "stripped_doc" : [
           "Draw the indicators corresponding to the given layout name",
           ""
         ],
-        "name" : "drawIndicators",
+        "def" : "MenubarFlag:drawIndicators(src)",
+        "parameters" : [
+          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
+          ""
+        ],
         "notes" : [
 
         ],
@@ -401,20 +398,20 @@
         "returns" : [
           " * The MenubarFlag object"
         ],
-        "def" : "MenubarFlag:drawIndicators(src)",
+        "name" : "drawIndicators",
         "desc" : "Draw the indicators corresponding to the given layout name"
       },
       {
         "doc" : "Draw indicators for the current keyboard method or layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
-        "parameters" : [
-          " * None",
-          ""
-        ],
         "stripped_doc" : [
           "Draw indicators for the current keyboard method or layout",
           ""
         ],
-        "name" : "getLayoutAndDrawindicators",
+        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "parameters" : [
+          " * None",
+          ""
+        ],
         "notes" : [
 
         ],
@@ -423,18 +420,18 @@
         "returns" : [
           " * The MenubarFlag object"
         ],
-        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "name" : "getLayoutAndDrawindicators",
         "desc" : "Draw indicators for the current keyboard method or layout"
       },
       {
         "doc" : "Start the keyboard layout watcher to draw the menubar indicators.",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Start the keyboard layout watcher to draw the menubar indicators."
         ],
-        "name" : "start",
+        "def" : "MenubarFlag:start()",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -443,18 +440,18 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag:start()",
+        "name" : "start",
         "desc" : "Start the keyboard layout watcher to draw the menubar indicators."
       },
       {
         "doc" : "Remove indicators and stop the keyboard layout watcher",
-        "parameters" : [
-
-        ],
         "stripped_doc" : [
           "Remove indicators and stop the keyboard layout watcher"
         ],
-        "name" : "stop",
+        "def" : "MenubarFlag:stop()",
+        "parameters" : [
+
+        ],
         "notes" : [
 
         ],
@@ -463,9 +460,12 @@
         "returns" : [
 
         ],
-        "def" : "MenubarFlag:stop()",
+        "name" : "stop",
         "desc" : "Remove indicators and stop the keyboard layout watcher"
       }
+    ],
+    "Command" : [
+
     ],
     "name" : "MenubarFlag"
   }

--- a/Source/MenubarFlag.spoon/docs.json
+++ b/Source/MenubarFlag.spoon/docs.json
@@ -1,208 +1,472 @@
 [
   {
-    "Command": [],
-    "Constant": [],
-    "Constructor": [],
-    "Deprecated": [],
-    "Field": [],
-    "Function": [],
-    "Method": [
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
       {
-        "def": "MenubarFlag:drawIndicators(src)",
-        "desc": "Draw the indicators corresponding to the given layout name",
-        "doc": "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
-        "name": "drawIndicators",
-        "parameters": [
-          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen."
+        "doc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
+        "parameters" : [
+
         ],
-        "returns": [
-          " * The MenubarFlag object"
+        "stripped_doc" : [
+          "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
         ],
-        "signature": "MenubarFlag:drawIndicators(src)",
-        "stripped_doc": "",
-        "type": "Method"
+        "name" : "allScreens",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.allScreens",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.allScreens",
+        "desc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
       },
       {
-        "def": "MenubarFlag:getLayoutAndDrawindicators",
-        "desc": "Draw indicators for the current keyboard layout",
-        "doc": "Draw indicators for the current keyboard layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
-        "name": "getLayoutAndDrawindicators",
-        "parameters": [
-          " * None"
+        "doc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
+        "parameters" : [
+
         ],
-        "returns": [
-          " * The MenubarFlag object"
+        "stripped_doc" : [
+          "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
         ],
-        "signature": "MenubarFlag:getLayoutAndDrawindicators",
-        "stripped_doc": "",
-        "type": "Method"
+        "name" : "indicatorHeight",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorHeight",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorHeight",
+        "desc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
       },
       {
-        "def": "MenubarFlag:start()",
-        "desc": "Start the keyboard layout watcher to draw the menubar indicators.",
-        "doc": "Start the keyboard layout watcher to draw the menubar indicators.",
-        "name": "start",
-        "signature": "MenubarFlag:start()",
-        "stripped_doc": "",
-        "type": "Method"
+        "doc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
+        ],
+        "name" : "indicatorAlpha",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorAlpha",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorAlpha",
+        "desc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
       },
       {
-        "def": "MenubarFlag:stop()",
-        "desc": "Remove indicators and stop the keyboard layout watcher",
-        "doc": "Remove indicators and stop the keyboard layout watcher",
-        "name": "stop",
-        "signature": "MenubarFlag:stop()",
-        "stripped_doc": "",
-        "type": "Method"
+        "doc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
+        ],
+        "name" : "indicatorInAllSpaces",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorInAllSpaces",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "desc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
+      },
+      {
+        "doc" : "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Table that contains the configuration of indicator colors",
+          "",
+          "The table below indicates the colors to use for a given keyboard",
+          "layout. The index is the name of the layout as it appears in the",
+          "input source menu. The value of each indicator is a table made of",
+          "an arbitrary number of segments, which will be distributed evenly",
+          "across the width of the screen. Each segment must be a valid",
+          "`hs.drawing.color` specification (most commonly, you should just",
+          "use the named colors from within the tables). If a layout is not",
+          "found, then the indicators are removed when that layout is active.",
+          "",
+          "Indicator specs can be static flag-like:",
+          "```",
+          "  Spanish = {col.green, col.white, col.red},",
+          "  German = {col.black, col.red, col.yellow},",
+          "```",
+          "or complex, programmatically-generated:",
+          "```",
+          "[\"U.S.\"] = (",
+          "   function() res={} ",
+          "      for i = 0,10,1 do",
+          "         table.insert(res, col.blue)",
+          "         table.insert(res, col.white)",
+          "         table.insert(res, col.red)",
+          "      end",
+          "      return res",
+          "   end)()",
+          "```",
+          "or solid colors:",
+          "```",
+          "  Spanish = {col.red},",
+          "  German = {col.yellow},",
+          "```",
+          "Contributions of indicator specs are welcome!"
+        ],
+        "name" : "colors",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.colors",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.colors",
+        "desc" : "Table that contains the configuration of indicator colors"
       }
     ],
-    "Variable": [
-      {
-        "def": "MenubarFlag.allScreens",
-        "desc": "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "doc": "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "name": "allScreens",
-        "signature": "MenubarFlag.allScreens",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.colors",
-        "desc": "Table that contains the configuration of indicator colors",
-        "doc": "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "name": "colors",
-        "signature": "MenubarFlag.colors",
-        "stripped_doc": "The table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.indicatorAlpha",
-        "desc": "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "doc": "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "name": "indicatorAlpha",
-        "signature": "MenubarFlag.indicatorAlpha",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.indicatorHeight",
-        "desc": "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "doc": "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "name": "indicatorHeight",
-        "signature": "MenubarFlag.indicatorHeight",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.indicatorInAllSpaces",
-        "desc": "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "doc": "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "name": "indicatorInAllSpaces",
-        "signature": "MenubarFlag.indicatorInAllSpaces",
-        "stripped_doc": "",
-        "type": "Variable"
-      }
+    "stripped_doc" : [
+
     ],
-    "desc": "Color the menubar according to the current keyboard layout",
-    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
-    "items": [
+    "desc" : "Color the menubar according to the current keyboard layout",
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "Constructor" : [
+
+    ],
+    "doc" : "Color the menubar according to the current keyboard layout\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https:\/\/pqrs.org\/osx\/ShowyEdge\/index.html.en)",
+    "Method" : [
       {
-        "def": "MenubarFlag.allScreens",
-        "desc": "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "doc": "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
-        "name": "allScreens",
-        "signature": "MenubarFlag.allScreens",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.colors",
-        "desc": "Table that contains the configuration of indicator colors",
-        "doc": "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "name": "colors",
-        "signature": "MenubarFlag.colors",
-        "stripped_doc": "The table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag:drawIndicators(src)",
-        "desc": "Draw the indicators corresponding to the given layout name",
-        "doc": "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
-        "name": "drawIndicators",
-        "parameters": [
-          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen."
+        "doc" : "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
+        "parameters" : [
+          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
+          ""
         ],
-        "returns": [
+        "stripped_doc" : [
+          "Draw the indicators corresponding to the given layout name",
+          ""
+        ],
+        "name" : "drawIndicators",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:drawIndicators(src)",
+        "type" : "Method",
+        "returns" : [
           " * The MenubarFlag object"
         ],
-        "signature": "MenubarFlag:drawIndicators(src)",
-        "stripped_doc": "",
-        "type": "Method"
+        "def" : "MenubarFlag:drawIndicators(src)",
+        "desc" : "Draw the indicators corresponding to the given layout name"
       },
       {
-        "def": "MenubarFlag:getLayoutAndDrawindicators",
-        "desc": "Draw indicators for the current keyboard layout",
-        "doc": "Draw indicators for the current keyboard layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
-        "name": "getLayoutAndDrawindicators",
-        "parameters": [
-          " * None"
+        "doc" : "Draw indicators for the current keyboard method or layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
+        "parameters" : [
+          " * None",
+          ""
         ],
-        "returns": [
+        "stripped_doc" : [
+          "Draw indicators for the current keyboard method or layout",
+          ""
+        ],
+        "name" : "getLayoutAndDrawindicators",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:getLayoutAndDrawindicators",
+        "type" : "Method",
+        "returns" : [
           " * The MenubarFlag object"
         ],
-        "signature": "MenubarFlag:getLayoutAndDrawindicators",
-        "stripped_doc": "",
-        "type": "Method"
+        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "desc" : "Draw indicators for the current keyboard method or layout"
       },
       {
-        "def": "MenubarFlag.indicatorAlpha",
-        "desc": "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "doc": "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
-        "name": "indicatorAlpha",
-        "signature": "MenubarFlag.indicatorAlpha",
-        "stripped_doc": "",
-        "type": "Variable"
+        "doc" : "Start the keyboard layout watcher to draw the menubar indicators.",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Start the keyboard layout watcher to draw the menubar indicators."
+        ],
+        "name" : "start",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:start()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag:start()",
+        "desc" : "Start the keyboard layout watcher to draw the menubar indicators."
       },
       {
-        "def": "MenubarFlag.indicatorHeight",
-        "desc": "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "doc": "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
-        "name": "indicatorHeight",
-        "signature": "MenubarFlag.indicatorHeight",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag.indicatorInAllSpaces",
-        "desc": "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "doc": "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
-        "name": "indicatorInAllSpaces",
-        "signature": "MenubarFlag.indicatorInAllSpaces",
-        "stripped_doc": "",
-        "type": "Variable"
-      },
-      {
-        "def": "MenubarFlag:start()",
-        "desc": "Start the keyboard layout watcher to draw the menubar indicators.",
-        "doc": "Start the keyboard layout watcher to draw the menubar indicators.",
-        "name": "start",
-        "signature": "MenubarFlag:start()",
-        "stripped_doc": "",
-        "type": "Method"
-      },
-      {
-        "def": "MenubarFlag:stop()",
-        "desc": "Remove indicators and stop the keyboard layout watcher",
-        "doc": "Remove indicators and stop the keyboard layout watcher",
-        "name": "stop",
-        "signature": "MenubarFlag:stop()",
-        "stripped_doc": "",
-        "type": "Method"
+        "doc" : "Remove indicators and stop the keyboard layout watcher",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Remove indicators and stop the keyboard layout watcher"
+        ],
+        "name" : "stop",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:stop()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag:stop()",
+        "desc" : "Remove indicators and stop the keyboard layout watcher"
       }
     ],
-    "name": "MenubarFlag",
-    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
-    "submodules": [],
-    "type": "Module"
+    "Field" : [
+
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
+        ],
+        "name" : "allScreens",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.allScreens",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.allScreens",
+        "desc" : "Boolean to specify whether the indicators should be shown on all monitors or just the current one. Defaults to `true`"
+      },
+      {
+        "doc" : "Table that contains the configuration of indicator colors\n\nThe table below indicates the colors to use for a given keyboard\nlayout. The index is the name of the layout as it appears in the\ninput source menu. The value of each indicator is a table made of\nan arbitrary number of segments, which will be distributed evenly\nacross the width of the screen. Each segment must be a valid\n`hs.drawing.color` specification (most commonly, you should just\nuse the named colors from within the tables). If a layout is not\nfound, then the indicators are removed when that layout is active.\n\nIndicator specs can be static flag-like:\n```\n  Spanish = {col.green, col.white, col.red},\n  German = {col.black, col.red, col.yellow},\n```\nor complex, programmatically-generated:\n```\n[\"U.S.\"] = (\n   function() res={} \n      for i = 0,10,1 do\n         table.insert(res, col.blue)\n         table.insert(res, col.white)\n         table.insert(res, col.red)\n      end\n      return res\n   end)()\n```\nor solid colors:\n```\n  Spanish = {col.red},\n  German = {col.yellow},\n```\nContributions of indicator specs are welcome!",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Table that contains the configuration of indicator colors",
+          "",
+          "The table below indicates the colors to use for a given keyboard",
+          "layout. The index is the name of the layout as it appears in the",
+          "input source menu. The value of each indicator is a table made of",
+          "an arbitrary number of segments, which will be distributed evenly",
+          "across the width of the screen. Each segment must be a valid",
+          "`hs.drawing.color` specification (most commonly, you should just",
+          "use the named colors from within the tables). If a layout is not",
+          "found, then the indicators are removed when that layout is active.",
+          "",
+          "Indicator specs can be static flag-like:",
+          "```",
+          "  Spanish = {col.green, col.white, col.red},",
+          "  German = {col.black, col.red, col.yellow},",
+          "```",
+          "or complex, programmatically-generated:",
+          "```",
+          "[\"U.S.\"] = (",
+          "   function() res={} ",
+          "      for i = 0,10,1 do",
+          "         table.insert(res, col.blue)",
+          "         table.insert(res, col.white)",
+          "         table.insert(res, col.red)",
+          "      end",
+          "      return res",
+          "   end)()",
+          "```",
+          "or solid colors:",
+          "```",
+          "  Spanish = {col.red},",
+          "  German = {col.yellow},",
+          "```",
+          "Contributions of indicator specs are welcome!"
+        ],
+        "name" : "colors",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.colors",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.colors",
+        "desc" : "Table that contains the configuration of indicator colors"
+      },
+      {
+        "doc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
+        ],
+        "name" : "indicatorAlpha",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorAlpha",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorAlpha",
+        "desc" : "Number to specify the indicator transparency (0.0 - invisible; 1.0 - fully opaque). Defaults to 0.3"
+      },
+      {
+        "doc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
+        ],
+        "name" : "indicatorHeight",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorHeight",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorHeight",
+        "desc" : "Number to specify the height of the indicator. Specify 0.0-1.0 to specify a percentage of the height of the menu bar, larger values indicate a fixed height in pixels. Defaults to 1.0"
+      },
+      {
+        "doc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
+        ],
+        "name" : "indicatorInAllSpaces",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag.indicatorInAllSpaces",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag.indicatorInAllSpaces",
+        "desc" : "Boolean to specify whether the indicator should be shown in all spaces (this includes full-screen mode). Defaults to `true`"
+      },
+      {
+        "doc" : "Draw the indicators corresponding to the given layout name\n\nParameters:\n * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.\n\nReturns:\n * The MenubarFlag object",
+        "parameters" : [
+          " * src - name of the layout to draw. If the given element exists in `MenubarFlag.colors`, it will be drawn. If it does not exist, then the indicators will be removed from the screen.",
+          ""
+        ],
+        "stripped_doc" : [
+          "Draw the indicators corresponding to the given layout name",
+          ""
+        ],
+        "name" : "drawIndicators",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:drawIndicators(src)",
+        "type" : "Method",
+        "returns" : [
+          " * The MenubarFlag object"
+        ],
+        "def" : "MenubarFlag:drawIndicators(src)",
+        "desc" : "Draw the indicators corresponding to the given layout name"
+      },
+      {
+        "doc" : "Draw indicators for the current keyboard method or layout\n\nParameters:\n * None\n\nReturns:\n * The MenubarFlag object",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "stripped_doc" : [
+          "Draw indicators for the current keyboard method or layout",
+          ""
+        ],
+        "name" : "getLayoutAndDrawindicators",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:getLayoutAndDrawindicators",
+        "type" : "Method",
+        "returns" : [
+          " * The MenubarFlag object"
+        ],
+        "def" : "MenubarFlag:getLayoutAndDrawindicators",
+        "desc" : "Draw indicators for the current keyboard method or layout"
+      },
+      {
+        "doc" : "Start the keyboard layout watcher to draw the menubar indicators.",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Start the keyboard layout watcher to draw the menubar indicators."
+        ],
+        "name" : "start",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:start()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag:start()",
+        "desc" : "Start the keyboard layout watcher to draw the menubar indicators."
+      },
+      {
+        "doc" : "Remove indicators and stop the keyboard layout watcher",
+        "parameters" : [
+
+        ],
+        "stripped_doc" : [
+          "Remove indicators and stop the keyboard layout watcher"
+        ],
+        "name" : "stop",
+        "notes" : [
+
+        ],
+        "signature" : "MenubarFlag:stop()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "MenubarFlag:stop()",
+        "desc" : "Remove indicators and stop the keyboard layout watcher"
+      }
+    ],
+    "name" : "MenubarFlag"
   }
 ]

--- a/Source/MenubarFlag.spoon/init.lua
+++ b/Source/MenubarFlag.spoon/init.lua
@@ -168,7 +168,7 @@ end
 
 --- MenubarFlag:getLayoutAndDrawindicators
 --- Method
---- Draw indicators for the current keyboard layout
+--- Draw indicators for the current keyboard method or layout
 ---
 --- Parameters:
 ---  * None
@@ -176,7 +176,7 @@ end
 --- Returns:
 ---  * The MenubarFlag object
 function obj:getLayoutAndDrawIndicators()
-   return self:drawIndicators(hs.keycodes.currentLayout())
+   return self:drawIndicators(hs.keycodes.currentMethod() or hs.keycodes.currentLayout())
 end
 
 --- MenubarFlag:start()

--- a/Source/MenubarFlag.spoon/init.lua
+++ b/Source/MenubarFlag.spoon/init.lua
@@ -188,6 +188,8 @@ function obj:start()
    hs.keycodes.inputSourceChanged(function()
          self:getLayoutAndDrawIndicators()
    end)
+   -- This solves the problem that the callback would not be called until the second layout change after a restart
+   hs.focus()
    return self
 end
 


### PR DESCRIPTION
Coalescing https://github.com/Hammerspoon/Spoons/pull/22 and https://github.com/Hammerspoon/Spoons/pull/34, for the following changes:

- Some keyboard layouts are not detected by hs.keycodes.currentLayout()
but by hs.keycodes.currentMethod(). Use whichever of the two has
a value to get the current layout. This fixes detection for Chinese
and other layouts. Reported and fixed originally by @liukun
at zzamboni/dot-hammerspoon#7
- Fix the problem that the callback would not be called until the second layout change after a restart. Somehow focusing HS triggers the callback and then it works well afterwards.