### PR TITLE
New Spoon: WindowScreenLeftAndRight

### DIFF
--- a/Source/WindowScreenLeftAndRight.spoon/docs.json
+++ b/Source/WindowScreenLeftAndRight.spoon/docs.json
@@ -1,0 +1,182 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "parameters" : [
+
+        ],
+        "name" : "logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "def" : "WindowScreenLeftAndRight.logger"
+      },
+      {
+        "doc" : "Table containing a sample set of hotkeys that can be\nassigned to the different operations. These are not bound\nby default - if you want to use them you have to call:\n`spoon.WindowScreenLeftAndRight:bindHotkeys(spoon.WindowScreenLeftAndRight.defaultHotkeys)`\nafter loading the spoon. Value:\n```\n {\n    screen_left = { {\"ctrl\", \"alt\", \"cmd\"}, \"Left\" },\n    screen_right= { {\"ctrl\", \"alt\", \"cmd\"}, \"Right\" },\n }\n```",
+        "parameters" : [
+
+        ],
+        "name" : "defaultHotkeys",
+        "stripped_doc" : [
+          "Table containing a sample set of hotkeys that can be",
+          "assigned to the different operations. These are not bound",
+          "by default - if you want to use them you have to call:",
+          "`spoon.WindowScreenLeftAndRight:bindHotkeys(spoon.WindowScreenLeftAndRight.defaultHotkeys)`",
+          "after loading the spoon. Value:",
+          "```",
+          " {",
+          "    screen_left = { {\"ctrl\", \"alt\", \"cmd\"}, \"Left\" },",
+          "    screen_right= { {\"ctrl\", \"alt\", \"cmd\"}, \"Right\" },",
+          " }",
+          "```"
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight.defaultHotkeys",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "desc" : "Table containing a sample set of hotkeys that can be",
+        "def" : "WindowScreenLeftAndRight.defaultHotkeys"
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "desc" : "Move windows to other screens",
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "Constructor" : [
+
+    ],
+    "doc" : "Move windows to other screens\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/WindowScreenLeftAndRight.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/WindowScreenLeftAndRight.spoon.zip)",
+    "Method" : [
+      {
+        "doc" : "Binds hotkeys for WindowScreenLeftAndRight\n\nParameters:\n * mapping - A table containing hotkey objifier\/key details for the following items:\n  * screen_left, screen_right - move the window to the left\/right screen (if you have more than one monitor connected, does nothing otherwise)",
+        "parameters" : [
+          " * mapping - A table containing hotkey objifier\/key details for the following items:",
+          "  * screen_left, screen_right - move the window to the left\/right screen (if you have more than one monitor connected, does nothing otherwise)"
+        ],
+        "name" : "bindHotkeys",
+        "stripped_doc" : [
+          "Binds hotkeys for WindowScreenLeftAndRight",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "desc" : "Binds hotkeys for WindowScreenLeftAndRight",
+        "def" : "WindowScreenLeftAndRight:bindHotkeys(mapping)"
+      }
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Table containing a sample set of hotkeys that can be\nassigned to the different operations. These are not bound\nby default - if you want to use them you have to call:\n`spoon.WindowScreenLeftAndRight:bindHotkeys(spoon.WindowScreenLeftAndRight.defaultHotkeys)`\nafter loading the spoon. Value:\n```\n {\n    screen_left = { {\"ctrl\", \"alt\", \"cmd\"}, \"Left\" },\n    screen_right= { {\"ctrl\", \"alt\", \"cmd\"}, \"Right\" },\n }\n```",
+        "parameters" : [
+
+        ],
+        "name" : "defaultHotkeys",
+        "stripped_doc" : [
+          "Table containing a sample set of hotkeys that can be",
+          "assigned to the different operations. These are not bound",
+          "by default - if you want to use them you have to call:",
+          "`spoon.WindowScreenLeftAndRight:bindHotkeys(spoon.WindowScreenLeftAndRight.defaultHotkeys)`",
+          "after loading the spoon. Value:",
+          "```",
+          " {",
+          "    screen_left = { {\"ctrl\", \"alt\", \"cmd\"}, \"Left\" },",
+          "    screen_right= { {\"ctrl\", \"alt\", \"cmd\"}, \"Right\" },",
+          " }",
+          "```"
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight.defaultHotkeys",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "desc" : "Table containing a sample set of hotkeys that can be",
+        "def" : "WindowScreenLeftAndRight.defaultHotkeys"
+      },
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "parameters" : [
+
+        ],
+        "name" : "logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "def" : "WindowScreenLeftAndRight.logger"
+      },
+      {
+        "doc" : "Binds hotkeys for WindowScreenLeftAndRight\n\nParameters:\n * mapping - A table containing hotkey objifier\/key details for the following items:\n  * screen_left, screen_right - move the window to the left\/right screen (if you have more than one monitor connected, does nothing otherwise)",
+        "parameters" : [
+          " * mapping - A table containing hotkey objifier\/key details for the following items:",
+          "  * screen_left, screen_right - move the window to the left\/right screen (if you have more than one monitor connected, does nothing otherwise)"
+        ],
+        "name" : "bindHotkeys",
+        "stripped_doc" : [
+          "Binds hotkeys for WindowScreenLeftAndRight",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "WindowScreenLeftAndRight:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "desc" : "Binds hotkeys for WindowScreenLeftAndRight",
+        "def" : "WindowScreenLeftAndRight:bindHotkeys(mapping)"
+      }
+    ],
+    "Field" : [
+
+    ],
+    "name" : "WindowScreenLeftAndRight"
+  }
+]

--- a/Source/WindowScreenLeftAndRight.spoon/init.lua
+++ b/Source/WindowScreenLeftAndRight.spoon/init.lua
@@ -1,0 +1,88 @@
+--- === WindowScreenLeftAndRight ===
+---
+--- Move windows to other screens
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/WindowScreenLeftAndRight.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/WindowScreenLeftAndRight.spoon.zip)
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "WindowScreenLeftAndRight"
+obj.version = "0.1"
+obj.author = "Diego Zamboni <diego@zzamboni.org>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- WindowScreenLeftAndRight.logger
+--- Variable
+--- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.logger = hs.logger.new('WindowScreenLeftAndRight')
+
+--- WindowScreenLeftAndRight.defaultHotkeys
+--- Variable
+--- Table containing a sample set of hotkeys that can be
+--- assigned to the different operations. These are not bound
+--- by default - if you want to use them you have to call:
+--- `spoon.WindowScreenLeftAndRight:bindHotkeys(spoon.WindowScreenLeftAndRight.defaultHotkeys)`
+--- after loading the spoon. Value:
+--- ```
+---  {
+---     screen_left = { {"ctrl", "alt", "cmd"}, "Left" },
+---     screen_right= { {"ctrl", "alt", "cmd"}, "Right" },
+---  }
+--- ```
+obj.defaultHotkeys = {
+   screen_left = { {"ctrl", "alt", "cmd"}, "Left" },
+   screen_right= { {"ctrl", "alt", "cmd"}, "Right" },
+}
+
+-- Internal functions to store/restore the current value of setFrameCorrectness.
+local function _setFC()
+   obj._savedFC = hs.window.setFrameCorrectness
+   hs.window.setFrameCorrectness = obj.use_frame_correctness
+end
+
+local function _restoreFC()
+   hs.window.setFrameCorrectness = obj._savedFC
+end
+
+-- Move current window to a different screen
+function obj.moveCurrentWindowToScreen(how)
+   local win = hs.window.focusedWindow()
+   if win == nil then
+      return
+   end
+   _setFC()
+   if how == "left" then
+      win:moveOneScreenWest()
+   elseif how == "right" then
+      win:moveOneScreenEast()
+   end
+   _restoreFC()
+end
+
+-- --------------------------------------------------------------------
+-- Shortcut functions for those above, for the hotkeys
+-- --------------------------------------------------------------------
+
+obj.oneScreenLeft  = hs.fnutils.partial(obj.moveCurrentWindowToScreen, "left")
+obj.oneScreenRight = hs.fnutils.partial(obj.moveCurrentWindowToScreen, "right")
+
+--- WindowScreenLeftAndRight:bindHotkeys(mapping)
+--- Method
+--- Binds hotkeys for WindowScreenLeftAndRight
+---
+--- Parameters:
+---  * mapping - A table containing hotkey objifier/key details for the following items:
+---   * screen_left, screen_right - move the window to the left/right screen (if you have more than one monitor connected, does nothing otherwise)
+function obj:bindHotkeys(mapping)
+   local hotkeyDefinitions = {
+      screen_left = self.oneScreenLeft,
+      screen_right = self.oneScreenRight,
+   }
+   hs.spoons.bindHotkeysToSpec(hotkeyDefinitions, mapping)
+   return self
+end
+
+return obj


### PR DESCRIPTION
Assign keybindings to move the current window to the left or the right. Light wrapper around `hs.window:moveOneScreenWest/East()`

(resubmission of https://github.com/Hammerspoon/Spoons/pull/16)