### PR TITLE
Encapsulate reload configuration from getting started guide into a spoon

### DIFF
--- a/Source/ReloadConfiguration.spoon/docs.json
+++ b/Source/ReloadConfiguration.spoon/docs.json
@@ -1,24 +1,24 @@
 [
   {
-    "doc" : "AllowsDraws a circle around the mouse pointer when a hotkey is pressed",
+    "doc" : "Adds a hotkey to reload the hammerspoon configuration, and a pathwatcher to automatically reload on changes",
     "items" : [
       {
-        "doc" : "An `hs.drawing.color` table defining the colour of the circle. Defaults to red.",
+        "doc" : "List of directories to watch for changes, defaults to hs.configdir",
         "type" : "Variable",
-        "name" : "color",
-        "def" : "MouseCircle.color"
+        "name" : "watch_paths",
+        "def" : "ReloadConfiguration.watch_paths"
       },
       {
-        "doc" : "Binds hotkeys for MouseCircle\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause the mouse circle to be drawn",
+        "doc" : "Binds hotkeys for ReloadConfiguration\n\nParameters:\n * reloadConfiguration - This will cause the configuration to be reloaded.",
         "type" : "Method",
         "name" : "bindHotkeys",
         "def" : "ReloadConfiguration:bindHotkeys(mapping)"
       },
       {
-        "doc" : "Draws a circle around the mouse\n\nParameters:\n * None\n\nReturns:\n * None",
+        "doc" : "Starts a pathwatch for each directory in watch_paths\n\nParameters:\n * None\n\nReturns:\n * None",
         "type" : "Method",
-        "name" : "reloadConfiguration",
-        "def" : "ReloadConfiguration:reloadConfiguration()"
+        "name" : "start",
+        "def" : "ReloadConfiguration:start()"
       }
     ],
     "name" : "ReloadConfiguration",

--- a/Source/ReloadConfiguration.spoon/docs.json
+++ b/Source/ReloadConfiguration.spoon/docs.json
@@ -1,0 +1,27 @@
+[
+  {
+    "doc" : "AllowsDraws a circle around the mouse pointer when a hotkey is pressed",
+    "items" : [
+      {
+        "doc" : "An `hs.drawing.color` table defining the colour of the circle. Defaults to red.",
+        "type" : "Variable",
+        "name" : "color",
+        "def" : "MouseCircle.color"
+      },
+      {
+        "doc" : "Binds hotkeys for MouseCircle\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * show - This will cause the mouse circle to be drawn",
+        "type" : "Method",
+        "name" : "bindHotkeys",
+        "def" : "ReloadConfiguration:bindHotkeys(mapping)"
+      },
+      {
+        "doc" : "Draws a circle around the mouse\n\nParameters:\n * None\n\nReturns:\n * None",
+        "type" : "Method",
+        "name" : "reloadConfiguration",
+        "def" : "ReloadConfiguration:reloadConfiguration()"
+      }
+    ],
+    "name" : "ReloadConfiguration",
+    "desc" : "Reloads the configuration when a configuration file is changed or when a hotkey is pressed"
+  }
+]

--- a/Source/ReloadConfiguration.spoon/init.lua
+++ b/Source/ReloadConfiguration.spoon/init.lua
@@ -28,13 +28,8 @@ obj.watch_paths = { hs.configdir }
 ---  * mapping - A table containing hotkey modifier/key details for the following items:
 ---   * reloadConfiguration - This will cause the configuration to be reloaded
 function obj:bindHotkeys(mapping)
-    if (self.hotkey) then
-        self.hotkey:delete()
-    end
-    local mods = mapping["reloadConfiguration"][1]
-    local key = mapping["reloadConfiguration"][2]
-    self.hotkey = hs.hotkey.bind(mods, key, function() hs.reload() end)
-    return self
+   local def = { reloadConfiguration = hs.fnutils.partial(hs.reload, self) }
+   hs.spoons.bindHotkeysToSpec(def, mapping)
 end
 
 --- ReloadConfiguration:start()

--- a/Source/ReloadConfiguration.spoon/init.lua
+++ b/Source/ReloadConfiguration.spoon/init.lua
@@ -1,0 +1,53 @@
+--- === ReloadConfiguration ===
+---
+--- Adds a hotkey to reload the hammerspoon configuration, and a pathwatcher to automatically reload on changes.
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/ReloadConfiguration.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/ReloadConfiguration.spoon.zip)
+
+local obj = {}
+obj.__index = obj
+
+-- Metadata
+obj.name = "ReloadConfiguration"
+obj.version = "1.0"
+obj.author = "Jon Lorusso <jonlorusso@gmail.com>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+
+--- ReloadConfiguration.watch_paths
+--- Variable
+--- List of directories to watch for changes, defaults to hs.configdir
+obj.watch_paths = { hs.configdir }
+
+--- ReloadConfiguration:bindHotkeys(mapping)
+--- Method
+--- Binds hotkeys for ReloadConfiguration
+---
+--- Parameters:
+---  * mapping - A table containing hotkey modifier/key details for the following items:
+---   * reloadConfiguration - This will cause the configuration to be reloaded
+function obj:bindHotkeys(mapping)
+    if (self.hotkey) then
+        self.hotkey:delete()
+    end
+    local mods = mapping["reloadConfiguration"][1]
+    local key = mapping["reloadConfiguration"][2]
+    self.hotkey = hs.hotkey.bind(mods, key, function() hs.reload() end)
+    return self
+end
+
+--- ReloadConfiguration:start()
+--- Method
+--- Start ReloadConfiguration
+---
+--- Parameters:
+---  * None
+function obj:start()
+    self.watchers = {}
+    for _,dir in pairs(self.watch_paths) do
+        self.watchers[dir] = hs.pathwatcher.new(dir, hs.reload):start()
+    end
+end
+
+return obj


### PR DESCRIPTION
This spoon implements the reload configuration behavior described in the hammerspoon getting started guide (more or less).  It watches the configdir for changes and also provides a hotkey for manually reloading the configuration.