### PR TITLE
Fix outlook-to-omnifocus

### DIFF
--- a/Source/SendToOmniFocus.spoon/scripts/outlook-to-omnifocus.applescript
+++ b/Source/SendToOmniFocus.spoon/scripts/outlook-to-omnifocus.applescript
@@ -232,7 +232,11 @@ on item_Process(selectedItems, argv)
 		else
 			--FULL ITEM EXPORT
 			repeat with selectedItem in selectedItems
-				set theProps to (properties of selectedItem)
+				try
+					set theProps to (properties of selectedItem)
+				on error
+					set theProps to selectedItem
+				end try
 				try
 					set theAttachments to attachments of selectedItem
 					set raw_Attendees to attendees of selectedItem


### PR DESCRIPTION
Fix for changes to AppleScript in Outlook 15.39. The code still checks for the old behavior so it still works in old versions.