### PR TITLE
Fix outlook-to-omnifocus

### DIFF
--- a/Source/UniversalArchive.spoon/init.lua
+++ b/Source/UniversalArchive.spoon/init.lua
@@ -66,7 +66,7 @@ obj.evernote_delay_before_typing = 0.2
 function obj:evernoteArchive(where)
    local ev = hs.appfinder.appFromName("Evernote")
    -- Archiving Evernote notes
-   if ev:selectMenuItem({"Note", "Move To Notebook…"}) then
+   if (ev:selectMenuItem({"Note", "Move To Notebook…"}) or ev:selectMenuItem({"Note", "Move to Notebook…"})) then
       local dest = where 
       if dest == nil then
          dest = self.evernote_archive_notebook


### PR DESCRIPTION
Fix for changes to AppleScript in Outlook 15.39. The code still
checks for the old behavior so it still works in old versions.