### PR TITLE
Fix archiving in Evernote

### DIFF
--- a/Source/UniversalArchive.spoon/init.lua
+++ b/Source/UniversalArchive.spoon/init.lua
@@ -66,7 +66,7 @@ obj.evernote_delay_before_typing = 0.2
 function obj:evernoteArchive(where)
    local ev = hs.appfinder.appFromName("Evernote")
    -- Archiving Evernote notes
-   if ev:selectMenuItem({"Note", "Move To Notebook…"}) then
+   if (ev:selectMenuItem({"Note", "Move To Notebook…"}) or ev:selectMenuItem({"Note", "Move to Notebook…"})) then
       local dest = where 
       if dest == nil then
          dest = self.evernote_archive_notebook


### PR DESCRIPTION
Newer versions of Evernote changed the capitalization of the "Move to
Notebook" menu item, so we now look for both possibilities.