### PR TITLE
Enables routing URLs to lua functions

### DIFF
--- a/Source/URLDispatcher.spoon/docs.json
+++ b/Source/URLDispatcher.spoon/docs.json
@@ -56,10 +56,10 @@
         ],
         "stripped_doc" : [
           "URL dispatch rules.",
-          "A table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\" }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`."
+          "A table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\", function }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`."
         ],
         "name" : "url_patterns",
-        "doc" : "URL dispatch rules.\nA table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\" }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`.",
+        "doc" : "URL dispatch rules.\nA table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\", function }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`.",
         "notes" : [
 
         ],
@@ -224,10 +224,10 @@
         ],
         "stripped_doc" : [
           "URL dispatch rules.",
-          "A table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\" }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`."
+          "A table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\", function }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`."
         ],
         "name" : "url_patterns",
-        "doc" : "URL dispatch rules.\nA table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\" }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`.",
+        "doc" : "URL dispatch rules.\nA table containing a list of dispatch rules. Each rule should be its own table in the format: `{ \"url pattern\", \"application bundle ID\", function }`, and they are evaluated in the order they are declared. Note that the patterns are [Lua patterns](https:\/\/www.lua.org\/pil\/20.2.html) and not regular expressions. Defaults to an empty table, which has the effect of having all URLs dispatched to the `default_handler`.",
         "notes" : [
 
         ],

--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -69,12 +69,18 @@ function obj:dispatchURL(scheme, host, params, fullUrl)
    for i,pair in ipairs(self.url_patterns) do
       local p = pair[1]
       local app = pair[2]
+      local func = pair[3]
       if string.match(url, p) then
          id = app
          if id ~= nil then
             self.logger.df("Match found, opening with '%s'", id)
             hs.application.launchOrFocusByBundleID(id)
             hs.urlevent.openURLWithBundle(url, id)
+            return
+         end
+         if func ~= nil then
+            self.logger.df("Match found, calling func '%s'", func)
+            func(url)
             return
          end
       end


### PR DESCRIPTION
Useful for doing things like opening YouTube URLs in youtube-dl or mpv:

```lua
hs.loadSpoon('URLDispatcher')
spoon.URLDispatcher.url_patterns = {{ 
    "https?://%w-%.youtube.com/watch", nil, 
    function(url) 
        hs.execute('/usr/local/bin/mpv --ytdl --ytdl-format=mp4 "' .. url .. '"') 
    end 
}}
```