### PR TITLE
Caffeine - check if menu exists and remove if start invoked again

### DIFF
--- a/Source/Caffeine.spoon/init.lua
+++ b/Source/Caffeine.spoon/init.lua
@@ -60,6 +60,7 @@ end
 --- Returns:
 ---  * The Caffeine object
 function obj:start()
+    if self.menuBarItem then self:stop() end
     self.menuBarItem = hs.menubar.new()
     self.menuBarItem:setClickCallback(self.clicked)
     if (self.hotkeyToggle) then
@@ -80,7 +81,7 @@ end
 --- Returns:
 ---  * The Caffeine object
 function obj:stop()
-    self.menuBarItem:delete()
+    if self.menuBarItem then self.menuBarItem:delete() end
     if (self.hotkeyToggle) then
         self.hotkeyToggle:disable()
     end


### PR DESCRIPTION
May help with #63 

This pull checks to see if the menu already exists when start is invoked; if it does, it removes it first. The update also checks to see if menu exists before performing stop, which may prevent a possible error if stop were to be invoked before start.