### PR TITLE
RoundedCorners. Bugfix. Level variable was ignored

### DIFF
--- a/Source/RoundedCorners.spoon/init.lua
+++ b/Source/RoundedCorners.spoon/init.lua
@@ -117,7 +117,7 @@ function obj:render()
                 { action="clip", type="circle", center=data.center, radius=radius, reversePath=true, },
                 { action="fill", type="rectangle", frame={x=0, y=0, w=radius, h=radius, }, fillColor={ alpha=1, }},
                 { type="resetClip", }
-            ):behavior(hs.canvas.windowBehaviors.canJoinAllSpaces):show()
+            ):behavior(hs.canvas.windowBehaviors.canJoinAllSpaces):level(self.level):show()
         end
     end)
 end


### PR DESCRIPTION
The spoon now uses `level` variable which should control which level of the screens the corners are drawn at