### PR TITLE
New spoon: TimeMachineProgress

### DIFF
--- a/Source/TimeMachineProgress.spoon/docs.json
+++ b/Source/TimeMachineProgress.spoon/docs.json
@@ -1,0 +1,286 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.logger",
+        "name" : "logger"
+      },
+      {
+        "doc" : "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "stripped_doc" : [
+          "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.refresh_interval",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.refresh_interval",
+        "name" : "refresh_interval"
+      },
+      {
+        "doc" : "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "stripped_doc" : [
+          "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.backupIcon",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.backupIcon",
+        "name" : "backupIcon"
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "type" : "Module",
+    "desc" : "Show Time Machine backup progress in a menubar indicator.",
+    "Deprecated" : [
+
+    ],
+    "Constructor" : [
+
+    ],
+    "doc" : "Show Time Machine backup progress in a menubar indicator.\n\nIf no backup is in progress, the indicator disappears. When a\nbackup is in preparation of in progress, the indicator is shown,\nindicating current state\/progress of the backup.\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/TimeMachineProgress.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/TimeMachineProgress.spoon.zip)",
+    "Method" : [
+      {
+        "doc" : "Update the indicator",
+        "stripped_doc" : [
+          "Update the indicator"
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Update the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:refresh()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress:refresh()",
+        "name" : "refresh"
+      },
+      {
+        "doc" : "Starts the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "stripped_doc" : [
+          "Starts the indicator",
+          ""
+        ],
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Starts the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:start()",
+        "type" : "Method",
+        "returns" : [
+          " * The TimeMachineProgress object"
+        ],
+        "def" : "TimeMachineProgress:start()",
+        "name" : "start"
+      },
+      {
+        "doc" : "Stops the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "stripped_doc" : [
+          "Stops the indicator",
+          ""
+        ],
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Stops the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * The TimeMachineProgress object"
+        ],
+        "def" : "TimeMachineProgress:stop()",
+        "name" : "stop"
+      }
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "stripped_doc" : [
+          "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.backupIcon",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.backupIcon",
+        "name" : "backupIcon"
+      },
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.logger",
+        "name" : "logger"
+      },
+      {
+        "doc" : "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "stripped_doc" : [
+          "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress.refresh_interval",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress.refresh_interval",
+        "name" : "refresh_interval"
+      },
+      {
+        "doc" : "Update the indicator",
+        "stripped_doc" : [
+          "Update the indicator"
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Update the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:refresh()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "TimeMachineProgress:refresh()",
+        "name" : "refresh"
+      },
+      {
+        "doc" : "Starts the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "stripped_doc" : [
+          "Starts the indicator",
+          ""
+        ],
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Starts the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:start()",
+        "type" : "Method",
+        "returns" : [
+          " * The TimeMachineProgress object"
+        ],
+        "def" : "TimeMachineProgress:start()",
+        "name" : "start"
+      },
+      {
+        "doc" : "Stops the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "stripped_doc" : [
+          "Stops the indicator",
+          ""
+        ],
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Stops the indicator",
+        "notes" : [
+
+        ],
+        "signature" : "TimeMachineProgress:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * The TimeMachineProgress object"
+        ],
+        "def" : "TimeMachineProgress:stop()",
+        "name" : "stop"
+      }
+    ],
+    "Field" : [
+
+    ],
+    "name" : "TimeMachineProgress"
+  }
+]

--- a/Source/TimeMachineProgress.spoon/init.lua
+++ b/Source/TimeMachineProgress.spoon/init.lua
@@ -1,0 +1,166 @@
+--- === TimeMachineProgress ===
+---
+--- Show Time Machine backup progress in a menubar indicator.
+---
+--- If no backup is in progress, the indicator disappears. When a
+--- backup is in preparation of in progress, the indicator is shown,
+--- indicating current state/progress of the backup.
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip)
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "TimeMachineProgress"
+obj.version = "0.1"
+obj.author = "Diego Zamboni <diego@zzamboni.org>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- TimeMachineProgress.logger
+--- Variable
+--- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.logger = hs.logger.new('TimeMachineProgress')
+
+--- TimeMachineProgress.refresh_interval
+--- Variable
+--- Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.
+obj.refresh_interval = 5
+
+--- TimeMachineProgress.backupIcon
+--- Variable
+--- Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.
+obj.backupIcon = hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})
+
+-- Internal variables
+obj.menuBarItem = nil
+obj.timer = nil
+
+-- Status emulation - for debugging - developer use only!
+
+-- If this variable is not nil, its contents is used instead of the live output from `tmutil status` to determine the display. Useful for debugging.
+obj.emulatedoutput = nil
+
+-- Assign these sample values to obj.emulatedoutput to simulate different backup situations
+obj._nobackup = [[Backup session status:
+{
+    ClientID = "com.apple.backupd";
+    Percent = 1;
+    Running = 0;
+}
+]]
+
+  obj._preparingbackup = [[Backup session status:
+{
+    BackupPhase = ThinningPreBackup;
+    ClientID = "com.apple.backupd";
+    DateOfStateChange = "2018-03-01 05:41:00 +0000";
+    DestinationID = "B8371B75-9630-484E-BA38-816CE0A5AF43";
+    DestinationMountPoint = "/Volumes/UM00104-external";
+    Percent = "-1";
+    Running = 1;
+    Stopping = 0;
+}]]
+
+  obj._runningbackup = [[Backup session status:
+{
+    BackupPhase = Copying;
+    ClientID = "com.apple.backupd";
+    DateOfStateChange = "2018-02-28 09:48:14 +0000";
+    DestinationID = "B8371B75-9630-484E-BA38-816CE0A5AF43";
+    DestinationMountPoint = "/Volumes/UM00104-external";
+    Percent = "0.4705918869508601";
+    Progress =     {
+        TimeRemaining = 37157;
+        "_raw_totalBytes" = 57210248107;
+        bytes = 29914087344;
+        files = 616013;
+        totalBytes = 62931272917;
+        totalFiles = 796246;
+    };
+    Running = 1;
+    Stopping = 0;
+    "_raw_Percent" = "0.5228798743898445";
+}]]
+
+  ;
+
+--- TimeMachineProgress:refresh()
+--- Method
+--- Update the indicator
+function obj:refresh()
+  out = nil
+  if obj.emulatedoutput then
+    out = obj.emulatedoutput
+  else
+    out = hs.execute("/usr/bin/tmutil status")
+  end
+  running = tonumber(string.match(out, "Running = (%d)"))
+  percent = tonumber(string.match(out, "Percent = %\"([-.%d]+)"))
+  self.logger.df("tmutil status output: %s\n", out)
+  self.logger.df("running = %d, percent = %s\n", running, percent)
+  if running == 1 then
+    self.logger.df("Backup is running")
+    if (not self.menuBarItem) then
+      self.menuBarItem = hs.menubar.new()
+      self.menuBarItem:setIcon(self.backupIcon, false)
+    end
+    title = nil
+    if (percent == -1) then
+      title = "(prep)"
+    else
+      title = string.format("%.2f%%", percent*100)
+    end
+    self.logger.df("Setting up menubar title to '%s'", title)
+    self.menuBarItem:setTitle(title)
+  else
+    self.logger.df("Backup not running, removing menubar item")
+    if self.menuBarItem then self.menuBarItem:delete() end
+    self.menuBarItem = nil
+  end
+  return self
+end
+
+--- TimeMachineProgress:start()
+--- Method
+--- Starts the indicator
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The TimeMachineProgress object
+function obj:start()
+  self:stop()
+
+  self.timer = hs.timer.doEvery(self.refresh_interval,
+                                function() self:refresh() end)
+
+  return self
+end
+
+--- TimeMachineProgress:stop()
+--- Method
+--- Stops the indicator
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The TimeMachineProgress object
+function obj:stop()
+  if self.menuBarItem then
+    self.menuBarItem:delete()
+  end
+  if self.timer then
+    self.timer:stop()
+  end
+
+  self.menuBarItem = nil
+  self.timer = nil
+
+  return self
+end
+
+return obj

--- a/docs/TimeMachineProgress.html
+++ b/docs/TimeMachineProgress.html
@@ -1,0 +1,174 @@
+<html>
+    <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Hammerspoon docs: TimeMachineProgress</title>
+    <style type="text/css">
+      a { text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      th { background-color: #DDDDDD; vertical-align: top; padding: 3px; }
+      td { width: 100%; background-color: #EEEEEE; vertical-align: top; padding: 3px; }
+      table { width: 100% ; border: 1px solid #0; text-align: left; }
+      section > table table td { width: 0; }
+    </style>
+    <link rel="stylesheet" href="docs.css" type="text/css" media="screen" />
+  </head>
+  <body>
+    <header>
+      <h1><a href="./index.html">docs</a> &raquo; TimeMachineProgress</h1>
+      <p>Show Time Machine backup progress in a menubar indicator.</p>
+<p>If no backup is in progress, the indicator disappears. When a
+backup is in preparation of in progress, the indicator is shown,
+indicating current state/progress of the backup.</p>
+<p>Download: <a href="https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip">https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip</a></p>
+
+      </header>
+      <h3>API Overview</h3>
+      <ul>
+        <li>Variables - Configurable values</li>
+          <ul>
+            <li><a href="#backupIcon">backupIcon</a></li>
+            <li><a href="#logger">logger</a></li>
+            <li><a href="#refresh_interval">refresh_interval</a></li>
+          </ul>
+        <li>Methods - API calls which can only be made on an object returned by a constructor</li>
+          <ul>
+            <li><a href="#refresh">refresh</a></li>
+            <li><a href="#start">start</a></li>
+            <li><a href="#stop">stop</a></li>
+          </ul>
+      </ul>
+      <h3>API Documentation</h3>
+        <h4 class="documentation-section">Variables</h4>
+          <section id="backupIcon">
+            <a name="//apple_ref/cpp/Variable/backupIcon" class="dashAnchor"></a>
+            <h5><a href="#backupIcon">backupIcon</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress.backupIcon</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Variable</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Image to use for the indicator. Defaults to the Time Machine application icon, obtained as <code>hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})</code>.</p>
+</td>
+              </tr>
+            </table>
+          </section>
+          <section id="logger">
+            <a name="//apple_ref/cpp/Variable/logger" class="dashAnchor"></a>
+            <h5><a href="#logger">logger</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress.logger</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Variable</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.</p>
+</td>
+              </tr>
+            </table>
+          </section>
+          <section id="refresh_interval">
+            <a name="//apple_ref/cpp/Variable/refresh_interval" class="dashAnchor"></a>
+            <h5><a href="#refresh_interval">refresh_interval</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress.refresh_interval</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Variable</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.</p>
+</td>
+              </tr>
+            </table>
+          </section>
+        <h4 class="documentation-section">Methods</h4>
+          <section id="refresh">
+            <a name="//apple_ref/cpp/Method/refresh" class="dashAnchor"></a>
+            <h5><a href="#refresh">refresh</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress:refresh()</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Method</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Update the indicator</p>
+</td>
+              </tr>
+            </table>
+          </section>
+          <section id="start">
+            <a name="//apple_ref/cpp/Method/start" class="dashAnchor"></a>
+            <h5><a href="#start">start</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress:start()</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Method</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Starts the indicator</p>
+<p>Parameters:</p>
+<ul>
+<li>None</li>
+</ul>
+<p>Returns:</p>
+<ul>
+<li>The TimeMachineProgress object</li>
+</ul>
+</td>
+              </tr>
+            </table>
+          </section>
+          <section id="stop">
+            <a name="//apple_ref/cpp/Method/stop" class="dashAnchor"></a>
+            <h5><a href="#stop">stop</a></h5>
+            <table>
+              <tr>
+                <th>Signature</th>
+                <td><code>TimeMachineProgress:stop()</code></td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td>Method</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td><p>Stops the indicator</p>
+<p>Parameters:</p>
+<ul>
+<li>None</li>
+</ul>
+<p>Returns:</p>
+<ul>
+<li>The TimeMachineProgress object</li>
+</ul>
+</td>
+              </tr>
+            </table>
+          </section>
+  </body>
+</html>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4968,6 +4968,158 @@
     "Function": [],
     "Method": [
       {
+        "def": "TimeMachineProgress:refresh()",
+        "desc": "Update the indicator",
+        "doc": "Update the indicator",
+        "name": "refresh",
+        "signature": "TimeMachineProgress:refresh()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "TimeMachineProgress:start()",
+        "desc": "Starts the indicator",
+        "doc": "Starts the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "name": "start",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * The TimeMachineProgress object"
+        ],
+        "signature": "TimeMachineProgress:start()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "TimeMachineProgress:stop()",
+        "desc": "Stops the indicator",
+        "doc": "Stops the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "name": "stop",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * The TimeMachineProgress object"
+        ],
+        "signature": "TimeMachineProgress:stop()",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "Variable": [
+      {
+        "def": "TimeMachineProgress.backupIcon",
+        "desc": "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "doc": "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "name": "backupIcon",
+        "signature": "TimeMachineProgress.backupIcon",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "TimeMachineProgress.logger",
+        "desc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "doc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "name": "logger",
+        "signature": "TimeMachineProgress.logger",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "TimeMachineProgress.refresh_interval",
+        "desc": "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "doc": "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "name": "refresh_interval",
+        "signature": "TimeMachineProgress.refresh_interval",
+        "stripped_doc": "",
+        "type": "Variable"
+      }
+    ],
+    "desc": "Show Time Machine backup progress in a menubar indicator.",
+    "doc": "Show Time Machine backup progress in a menubar indicator.\n\nIf no backup is in progress, the indicator disappears. When a\nbackup is in preparation of in progress, the indicator is shown,\nindicating current state/progress of the backup.\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip)",
+    "items": [
+      {
+        "def": "TimeMachineProgress.backupIcon",
+        "desc": "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "doc": "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+        "name": "backupIcon",
+        "signature": "TimeMachineProgress.backupIcon",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "TimeMachineProgress.logger",
+        "desc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "doc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "name": "logger",
+        "signature": "TimeMachineProgress.logger",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "TimeMachineProgress:refresh()",
+        "desc": "Update the indicator",
+        "doc": "Update the indicator",
+        "name": "refresh",
+        "signature": "TimeMachineProgress:refresh()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "TimeMachineProgress.refresh_interval",
+        "desc": "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "doc": "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+        "name": "refresh_interval",
+        "signature": "TimeMachineProgress.refresh_interval",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "TimeMachineProgress:start()",
+        "desc": "Starts the indicator",
+        "doc": "Starts the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "name": "start",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * The TimeMachineProgress object"
+        ],
+        "signature": "TimeMachineProgress:start()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "TimeMachineProgress:stop()",
+        "desc": "Stops the indicator",
+        "doc": "Stops the indicator\n\nParameters:\n * None\n\nReturns:\n * The TimeMachineProgress object",
+        "name": "stop",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * The TimeMachineProgress object"
+        ],
+        "signature": "TimeMachineProgress:stop()",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "name": "TimeMachineProgress",
+    "stripped_doc": "\nIf no backup is in progress, the indicator disappears. When a\nbackup is in preparation of in progress, the indicator is shown,\nindicating current state/progress of the backup.\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TimeMachineProgress.spoon.zip)",
+    "submodules": [],
+    "type": "Module"
+  },
+  {
+    "Command": [],
+    "Constant": [],
+    "Constructor": [],
+    "Deprecated": [],
+    "Field": [],
+    "Function": [],
+    "Method": [
+      {
         "def": "ToggleScreenRotation:bindHotkeys(mapping)",
         "desc": "Binds hotkeys for ToggleScreenRotation.",
         "doc": "Binds hotkeys for ToggleScreenRotation.\n\nParameters:\n * mapping - A table containing hotkey modifier/key details to rotate screens. Instead of fixed \"key names\", each key must be the name of a screen to rotate, or a Lua pattern - in this case the first screen to match the pattern will be rotated. The value is a table containing the hotkey modifier/key details as usual. You can use the special key `first` (or the Lua pattern `[\".*\"]`) to match the first external screen, which should be sufficient unless you have more than one external screen. Example (bind Ctrl-Cmd-Alt-F15 to rotate the first external screen):\n   ```\n     [\".*\"] = { {\"ctrl\", \"cmd\", \"alt\"}, \"f15\" }\n   ```",

--- a/docs/docs_index.json
+++ b/docs/docs_index.json
@@ -1267,6 +1267,47 @@
     "type": "Module"
   },
   {
+    "desc": "Show Time Machine backup progress in a menubar indicator.",
+    "name": "TimeMachineProgress",
+    "type": "Module"
+  },
+  {
+    "desc": "Image to use for the indicator. Defaults to the Time Machine application icon, obtained as `hs.image.imageFromAppBundle('com.apple.backup.launcher'):setSize({w=16,h=16})`.",
+    "module": "TimeMachineProgress",
+    "name": "backupIcon",
+    "type": "Variable"
+  },
+  {
+    "desc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+    "module": "TimeMachineProgress",
+    "name": "logger",
+    "type": "Variable"
+  },
+  {
+    "desc": "Integer specifying how often the indicator should be refreshed. Defaults to 5 seconds.",
+    "module": "TimeMachineProgress",
+    "name": "refresh_interval",
+    "type": "Variable"
+  },
+  {
+    "desc": "Update the indicator",
+    "module": "TimeMachineProgress",
+    "name": "refresh",
+    "type": "Method"
+  },
+  {
+    "desc": "Starts the indicator",
+    "module": "TimeMachineProgress",
+    "name": "start",
+    "type": "Method"
+  },
+  {
+    "desc": "Stops the indicator",
+    "module": "TimeMachineProgress",
+    "name": "stop",
+    "type": "Method"
+  },
+  {
     "desc": "Toggle rotation on external screens",
     "name": "ToggleScreenRotation",
     "type": "Module"

--- a/docs/index.html
+++ b/docs/index.html
@@ -245,6 +245,11 @@
 </td>
             </tr>
             <tr>
+                <th><a href="TimeMachineProgress.html">TimeMachineProgress</a></th>
+                <td><p>Show Time Machine backup progress in a menubar indicator.</p>
+</td>
+            </tr>
+            <tr>
                 <th><a href="ToggleScreenRotation.html">ToggleScreenRotation</a></th>
                 <td><p>Toggle rotation on external screens</p>
 </td>


### PR DESCRIPTION
Show Time Machine backup progress in a menubar indicator.

If no backup is in progress, the indicator disappears. When a
backup is in preparation of in progress, the indicator is shown,
indicating current state/progress of the backup.