### PR TITLE
Add OpenApp

### DIFF
--- a/Source/OpenApp.spoon/docs.json
+++ b/Source/OpenApp.spoon/docs.json
@@ -1,0 +1,118 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+      {
+        "def" : "OpenApp.show()",
+        "stripped_doc" : [
+          "Call this function to pop chooser to choose applications."
+        ],
+        "doc" : "Call this function to pop chooser to choose applications.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.show()",
+        "type" : "Function",
+        "returns" : [
+
+        ],
+        "name" : "show",
+        "desc" : "Call this function to pop chooser to choose applications."
+      }
+    ],
+    "Variable" : [
+      {
+        "def" : "OpenApp.searchPath",
+        "stripped_doc" : [
+          "OpenApp search paths in this list for applications."
+        ],
+        "doc" : "OpenApp search paths in this list for applications.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.searchPath",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "searchPath",
+        "desc" : "OpenApp search paths in this list for applications."
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "desc" : "open a chooser to open apps.",
+    "Constructor" : [
+
+    ],
+    "items" : [
+      {
+        "def" : "OpenApp.searchPath",
+        "stripped_doc" : [
+          "OpenApp search paths in this list for applications."
+        ],
+        "doc" : "OpenApp search paths in this list for applications.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.searchPath",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "searchPath",
+        "desc" : "OpenApp search paths in this list for applications."
+      },
+      {
+        "def" : "OpenApp.show()",
+        "stripped_doc" : [
+          "Call this function to pop chooser to choose applications."
+        ],
+        "doc" : "Call this function to pop chooser to choose applications.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.show()",
+        "type" : "Function",
+        "returns" : [
+
+        ],
+        "name" : "show",
+        "desc" : "Call this function to pop chooser to choose applications."
+      }
+    ],
+    "Field" : [
+
+    ],
+    "doc" : "open a chooser to open apps.",
+    "Method" : [
+
+    ],
+    "Command" : [
+
+    ],
+    "name" : "OpenApp"
+  }
+]

--- a/Source/OpenApp.spoon/docs.json
+++ b/Source/OpenApp.spoon/docs.json
@@ -8,14 +8,14 @@
     ],
     "Function" : [
       {
-        "def" : "OpenApp.show()",
+        "doc" : "Call this function to pop chooser to choose applications.",
         "stripped_doc" : [
           "Call this function to pop chooser to choose applications."
         ],
-        "doc" : "Call this function to pop chooser to choose applications.",
         "parameters" : [
 
         ],
+        "desc" : "Call this function to pop chooser to choose applications.",
         "notes" : [
 
         ],
@@ -25,19 +25,19 @@
 
         ],
         "name" : "show",
-        "desc" : "Call this function to pop chooser to choose applications."
+        "def" : "OpenApp.show()"
       }
     ],
     "Variable" : [
       {
-        "def" : "OpenApp.searchPath",
+        "doc" : "OpenApp search paths in this list for applications.",
         "stripped_doc" : [
           "OpenApp search paths in this list for applications."
         ],
-        "doc" : "OpenApp search paths in this list for applications.",
         "parameters" : [
 
         ],
+        "desc" : "OpenApp search paths in this list for applications.",
         "notes" : [
 
         ],
@@ -47,7 +47,49 @@
 
         ],
         "name" : "searchPath",
-        "desc" : "OpenApp search paths in this list for applications."
+        "def" : "OpenApp.searchPath"
+      },
+      {
+        "doc" : "If you want to switch to a layout when enabled chooser,\nset this to name of that layout",
+        "stripped_doc" : [
+          "If you want to switch to a layout when enabled chooser,",
+          "set this to name of that layout"
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "If you want to switch to a layout when enabled chooser,",
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.forceLayout",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "forceLayout",
+        "def" : "OpenApp.forceLayout"
+      },
+      {
+        "doc" : "If you want to switch to a method when enabled chooser,\nset this to name of that method",
+        "stripped_doc" : [
+          "If you want to switch to a method when enabled chooser,",
+          "set this to name of that method"
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "If you want to switch to a method when enabled chooser,",
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.forceMethod",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "forceMethod",
+        "def" : "OpenApp.forceMethod"
       }
     ],
     "stripped_doc" : [
@@ -61,16 +103,68 @@
     "Constructor" : [
 
     ],
+    "doc" : "open a chooser to open apps.",
+    "Method" : [
+
+    ],
+    "Command" : [
+
+    ],
+    "Field" : [
+
+    ],
     "items" : [
       {
-        "def" : "OpenApp.searchPath",
+        "doc" : "If you want to switch to a layout when enabled chooser,\nset this to name of that layout",
         "stripped_doc" : [
-          "OpenApp search paths in this list for applications."
+          "If you want to switch to a layout when enabled chooser,",
+          "set this to name of that layout"
         ],
-        "doc" : "OpenApp search paths in this list for applications.",
         "parameters" : [
 
         ],
+        "desc" : "If you want to switch to a layout when enabled chooser,",
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.forceLayout",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "forceLayout",
+        "def" : "OpenApp.forceLayout"
+      },
+      {
+        "doc" : "If you want to switch to a method when enabled chooser,\nset this to name of that method",
+        "stripped_doc" : [
+          "If you want to switch to a method when enabled chooser,",
+          "set this to name of that method"
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "If you want to switch to a method when enabled chooser,",
+        "notes" : [
+
+        ],
+        "signature" : "OpenApp.forceMethod",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "forceMethod",
+        "def" : "OpenApp.forceMethod"
+      },
+      {
+        "doc" : "OpenApp search paths in this list for applications.",
+        "stripped_doc" : [
+          "OpenApp search paths in this list for applications."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "OpenApp search paths in this list for applications.",
         "notes" : [
 
         ],
@@ -80,17 +174,17 @@
 
         ],
         "name" : "searchPath",
-        "desc" : "OpenApp search paths in this list for applications."
+        "def" : "OpenApp.searchPath"
       },
       {
-        "def" : "OpenApp.show()",
+        "doc" : "Call this function to pop chooser to choose applications.",
         "stripped_doc" : [
           "Call this function to pop chooser to choose applications."
         ],
-        "doc" : "Call this function to pop chooser to choose applications.",
         "parameters" : [
 
         ],
+        "desc" : "Call this function to pop chooser to choose applications.",
         "notes" : [
 
         ],
@@ -100,18 +194,8 @@
 
         ],
         "name" : "show",
-        "desc" : "Call this function to pop chooser to choose applications."
+        "def" : "OpenApp.show()"
       }
-    ],
-    "Field" : [
-
-    ],
-    "doc" : "open a chooser to open apps.",
-    "Method" : [
-
-    ],
-    "Command" : [
-
     ],
     "name" : "OpenApp"
   }

--- a/Source/OpenApp.spoon/init.lua
+++ b/Source/OpenApp.spoon/init.lua
@@ -18,10 +18,24 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 --- OpenApp search paths in this list for applications.
 obj.searchPath = {'/Applications'}
 
+--- OpenApp.forceLayout
+--- Variable
+--- If you want to switch to a layout when enabled chooser,
+--- set this to name of that layout
+obj.forceLayout = nil
+
+--- OpenApp.forceMethod
+--- Variable
+--- If you want to switch to a method when enabled chooser,
+--- set this to name of that method
+obj.forceMethod = nil
+
 --- OpenApp.show()
 --- Function
 --- Call this function to pop chooser to choose applications.
 function obj.show()
+   hs.keycodes.setLayout(obj.forceLayout or '')
+   hs.keycodes.setMethod(obj.forceMethod or '')
    obj.chooser:show()
 end
 

--- a/Source/OpenApp.spoon/init.lua
+++ b/Source/OpenApp.spoon/init.lua
@@ -1,0 +1,59 @@
+--- === OpenApp ===
+---
+--- open a chooser to open apps.
+
+-- Metadata
+obj.name = "OpenApp"
+obj.version = "0.7"
+obj.author = "Yuan Fu <casouri@gmail.com>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+obj = {}
+obj.__index = obj
+
+--- OpenApp.searchPath
+--- Variable
+--- OpenApp search paths in this list for applications.
+obj.searchPath = {'/Applications'}
+
+--- OpenApp.show()
+--- Function
+--- Call this function to pop chooser to choose applications.
+function obj.show()
+   obj.chooser:show()
+end
+
+local function getAppList()
+   local appList = {}
+   for index = 1, #obj.searchPath do
+      -- resolve relative path and symlinks
+      local path = hs.fs.pathToAbsolute(obj.searchPath[index])
+      local iterFunc, dicTable = hs.fs.dir(path)
+      while true do
+         local fileName = iterFunc(dicTable)
+         -- when there are no other files
+         if not fileName then break end
+         if fileName ~= '.' and fileName ~= '..' then
+            table.insert(appList, {text=fileName})
+         end
+      end
+   end
+   return appList
+end
+
+local function openApp(appTable)
+   obj.chooser:hide()
+   if appTable then
+      hs.application.launchOrFocus(appTable.text)
+   end
+end
+
+function obj:init()
+   obj.chooser = hs.chooser.new(openApp)
+   obj.chooser:choices(getAppList)
+   obj.chooser:searchSubText(true)
+   return obj.chooser
+end
+
+return obj

--- a/Source/OpenApp.spoon/init.lua
+++ b/Source/OpenApp.spoon/init.lua
@@ -2,6 +2,9 @@
 ---
 --- open a chooser to open apps.
 
+obj = {}
+obj.__index = obj
+
 -- Metadata
 obj.name = "OpenApp"
 obj.version = "0.7"
@@ -9,8 +12,6 @@ obj.author = "Yuan Fu <casouri@gmail.com>"
 obj.homepage = "https://github.com/Hammerspoon/Spoons"
 obj.license = "MIT - https://opensource.org/licenses/MIT"
 
-obj = {}
-obj.__index = obj
 
 --- OpenApp.searchPath
 --- Variable


### PR DESCRIPTION
Because this spoon is really simple I'm not sure if it can be in. BUT, this is the one helps me replace Alfred. 

The Spoon basically pops a chooser for you to open applications.And that's basically all I use in Alfred.
( I set chooser to dark in my own config)
<img width="1440" alt="screen shot 2018-04-11 at 12 14 04 am" src="https://user-images.githubusercontent.com/13118647/38596039-4b029998-3d1d-11e8-8e3f-baa4cbd6380f.png">
<img width="1440" alt="screen shot 2018-04-11 at 12 14 07 am" src="https://user-images.githubusercontent.com/13118647/38596044-4f71ce90-3d1d-11e8-92b6-0d7a95ffe6d2.png">

BTW, the reason I'm not going with an all-in-one chooser(like Alfred) is that I want to use my Commander as the front page, and choose specific tool I want. 

**More specifically:**

- Alfred workflow: `invoke -- find(find file) -- (now you are searching for files) -- type -- enter`
- The workflow I'm thinking about:  `invoke commander -- type command(find file, find app, etc) -- enter -- (now you are searching for file/app -- type -- enter`

The second workflow is much easier to implement and maintain than an all-in-one chooser(Alfred). In the meantime, the second workflow is only one enter more than Alfred workflow.