### PR TITLE
Convert data to numbers

### DIFF
--- a/Source/SpeedMenu.spoon/init.lua
+++ b/Source/SpeedMenu.spoon/init.lua
@@ -20,8 +20,8 @@ function obj:init()
 end
 
 local function data_diff()
-    local in_seq = hs.execute(obj.instr)
-    local out_seq = hs.execute(obj.outstr)
+    local in_seq = tonumber(hs.execute(obj.instr))
+    local out_seq = tonumber(hs.execute(obj.outstr))
     local in_diff = in_seq - obj.inseq
     local out_diff = out_seq - obj.outseq
     if in_diff/1024 > 1024 then


### PR DESCRIPTION
This change ensure in_seq and out_seq are numbers for arithmetic. Based on resolving the below observed ERROR:

2018-04-18 11:33:42: 11:33:42 ERROR:   LuaSkin: hs.timer callback error: /path/to/hammerspoon/Spoons/SpeedMenu.spoon/init.lua:25: attempt to perform arithmetic on a string value (local 'in_seq')
stack traceback:
	/path/to/hammerspoon/Spoons/SpeedMenu.spoon/init.lua:25: in function </path/to/hammerspoon/Spoons/SpeedMenu.spoon/init.lua:22>