### PR TITLE
Add start(), stop(), and toggle() methods to SpeedMenu

### DIFF
--- a/Source/SpeedMenu.spoon/docs.json
+++ b/Source/SpeedMenu.spoon/docs.json
@@ -15,7 +15,7 @@
         "signature": "SpeedMenu:rescan()",
         "stripped_doc": "",
         "type": "Method"
-            },
+      },
       {
         "def": "SpeedMenu:start()",
         "desc": "Start SpeedMenu.",

--- a/Source/SpeedMenu.spoon/docs.json
+++ b/Source/SpeedMenu.spoon/docs.json
@@ -15,6 +15,33 @@
         "signature": "SpeedMenu:rescan()",
         "stripped_doc": "",
         "type": "Method"
+            },
+      {
+        "def": "SpeedMenu:start()",
+        "desc": "Start SpeedMenu.",
+        "doc": "Start SpeedMenu.\n",
+        "name": "start",
+        "signature": "SpeedMenu:start()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpeedMenu:stop()",
+        "desc": "Stop SpeedMenu.",
+        "doc": "Stop SpeedMenu.\n",
+        "name": "stop",
+        "signature": "SpeedMenu:stop()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpeedMenu:toggle()",
+        "desc": "If SpeedMenu is running, call SpeedMenu:stop(), otherwise call SpeedMenu:start().",
+        "doc": "If SpeedMenu is running, call SpeedMenu:stop(), otherwise call SpeedMenu:start().\n",
+        "name": "toggle",
+        "signature": "SpeedMenu:toggle()",
+        "stripped_doc": "",
+        "type": "Method"
       }
     ],
     "Variable": [],

--- a/Source/SpeedMenu.spoon/init.lua
+++ b/Source/SpeedMenu.spoon/init.lua
@@ -19,6 +19,24 @@ function obj:init()
     obj:rescan()
 end
 
+function obj:start()
+    obj.menubar:returnToMenuBar()
+    obj:rescan()
+end
+
+function obj:stop()
+    obj.menubar:removeFromMenuBar()
+    obj.timer:stop()
+end
+
+function obj:toggle()
+    if obj.timer:running() then
+        obj:stop()
+    else
+        obj:start()
+    end
+end
+
 local function data_diff()
     local in_seq = hs.execute(obj.instr)
     local out_seq = hs.execute(obj.outstr)

--- a/Source/SpeedMenu.spoon/init.lua
+++ b/Source/SpeedMenu.spoon/init.lua
@@ -15,8 +15,7 @@ obj.homepage = "https://github.com/Hammerspoon/Spoons"
 obj.license = "MIT - https://opensource.org/licenses/MIT"
 
 function obj:init()
-    self.menubar = hs.menubar.new()
-    obj:rescan()
+    self.menubar = hs.menubar.new(false)
 end
 
 function obj:start()


### PR DESCRIPTION
Added `start()`, `stop()`, and `toggle()`, methods in order to make it easier to turn SpeedMenu on and off without having to edit ones Hammerspoon config. Also added the documentation of those new methods.

The most controversial change in this pull request is commit e54f242 which changes the behavior of the spoon to not start when `init()` is called. This is inline with the recommendations set out in the [Hammerspoon Spoon Plugins Documentation](/Hammerspoon/hammerspoon/blob/master/SPOONS.md), but would change the default behavior for those currently using the spoon.

Related to issue #83.