### PR TITLE
Allow Seal Calc plugin to work on calculations that include commas and dollar signs

### DIFF
--- a/Source/Seal.spoon/seal_calc.lua
+++ b/Source/Seal.spoon/seal_calc.lua
@@ -16,11 +16,15 @@ function obj.bareCalc(query)
     if query == nil or query == "" then
         return choices
     end
+
+    -- Filter out commas and dollar signs
+    query, _ = query:gsub("[%,%$]", "")
+
     -- We need to determine if the query only contains mathematical calculations
     -- To do this we'll see if it matches the inverse of that set of characters
     if string.match(query, "[^%d^%.^%+^%-^/^%*^%^^ ^%(^%)]") == nil then
         local choice = {}
-        local compile_result,fn = load("return "..query)
+        local compile_result, fn = load("return " .. query)
         if type(compile_result) == "function" then
             local result = compile_result()
             choice["text"] = result


### PR DESCRIPTION
I often copy and paste numbers into Seal in order to perform some calculation. These numbers often include commas and dollar signs. The current Calc plugin does not match strings that include these chars, and so I have to manually go through and delete them in the string before Seal will perform the calculation and give me a result.

This pull request implements a really hacky fix for this by simply filtering out commas and dollar signs from `query`. There is probably a more elegant way to do this, but I haven't had the time to think about it, and this works quite well.

I'd be happy for someone to edit this pull request with a more elegant solution before merging this in, if you decide it's worthwhile.