### PR TITLE
MicMute spoon

### DIFF
--- a/Source/MicMute.spoon/docs.json
+++ b/Source/MicMute.spoon/docs.json
@@ -1,39 +1,125 @@
 [
   {
-    "Command" : [],
-    "Constant" : [],
-    "Constructor" : [],
-    "Deprecated" : [],
-    "Field" : [],
-    "Function" : [],
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+
+    ],
+    "stripped_doc" : [
+
+    ],
+    "desc" : "Microphone Mute Toggle and status indicator",
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "Constructor" : [
+
+    ],
+    "Field" : [
+
+    ],
     "Method" : [
       {
-        "def": "MicMute:toggleMicMute()",
-        "desc": "Toggle mic mute on/off",
-        "doc": "Toggle mic mute on/off",
-        "name": "toggleMicMute",
-        "signature": "MicMute:toggleMicMute()",
-        "stripped_doc": "",
-        "type": "Method"
+        "desc" : "Toggle mic mute on\/off",
+        "stripped_doc" : [
+          "Toggle mic mute on\/off"
+        ],
+        "def" : "MicMute:toggleMicMute()",
+        "doc" : "Toggle mic mute on\/off",
+        "notes" : [
+
+        ],
+        "signature" : "MicMute:toggleMicMute()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "toggleMicMute",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "desc" : "Binds hotkeys for MicMute",
+        "stripped_doc" : [
+          "Binds hotkeys for MicMute",
+          ""
+        ],
+        "def" : "MicMute:bindHotkeys(mapping, latch_timeout)",
+        "doc" : "Binds hotkeys for MicMute\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * toggle - This will cause the microphone mute status to be toggled. Hold for momentary, press quickly for toggle.\n * latch_timeout - Time in seconds to hold the hotkey before momentary mode takes over, in which the mute will be toggled again when hotkey is released. Latch if released before this time. 0.75 for 750 milliseconds is a good value.",
+        "notes" : [
+
+        ],
+        "signature" : "MicMute:bindHotkeys(mapping, latch_timeout)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing hotkey modifier\/key details for the following items:",
+          "  * toggle - This will cause the microphone mute status to be toggled. Hold for momentary, press quickly for toggle.",
+          " * latch_timeout - Time in seconds to hold the hotkey before momentary mode takes over, in which the mute will be toggled again when hotkey is released. Latch if released before this time. 0.75 for 750 milliseconds is a good value."
+        ]
       }
     ],
-    "Variable" : [],
-    "desc" : "Microphone Mute Toggle and status indicator",
-    "doc" : "Microphone Mute Toggle and status indicator\n\nDownload: [https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip](https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip)",
+    "Command" : [
+
+    ],
     "items" : [
       {
-        "def": "MicMute:toggleMicMute()",
-        "desc": "Toggle mic mute on/off",
-        "doc": "Toggle mic mute on/off",
-        "name": "toggleMicMute",
-        "signature": "MicMute:toggleMicMute()",
-        "stripped_doc": "",
-        "type": "Method"
+        "desc" : "Binds hotkeys for MicMute",
+        "stripped_doc" : [
+          "Binds hotkeys for MicMute",
+          ""
+        ],
+        "def" : "MicMute:bindHotkeys(mapping, latch_timeout)",
+        "doc" : "Binds hotkeys for MicMute\n\nParameters:\n * mapping - A table containing hotkey modifier\/key details for the following items:\n  * toggle - This will cause the microphone mute status to be toggled. Hold for momentary, press quickly for toggle.\n * latch_timeout - Time in seconds to hold the hotkey before momentary mode takes over, in which the mute will be toggled again when hotkey is released. Latch if released before this time. 0.75 for 750 milliseconds is a good value.",
+        "notes" : [
+
+        ],
+        "signature" : "MicMute:bindHotkeys(mapping, latch_timeout)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing hotkey modifier\/key details for the following items:",
+          "  * toggle - This will cause the microphone mute status to be toggled. Hold for momentary, press quickly for toggle.",
+          " * latch_timeout - Time in seconds to hold the hotkey before momentary mode takes over, in which the mute will be toggled again when hotkey is released. Latch if released before this time. 0.75 for 750 milliseconds is a good value."
+        ]
+      },
+      {
+        "desc" : "Toggle mic mute on\/off",
+        "stripped_doc" : [
+          "Toggle mic mute on\/off"
+        ],
+        "def" : "MicMute:toggleMicMute()",
+        "doc" : "Toggle mic mute on\/off",
+        "notes" : [
+
+        ],
+        "signature" : "MicMute:toggleMicMute()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "toggleMicMute",
+        "parameters" : [
+
+        ]
       }
     ],
-    "name" : "MicMute",
-    "stripped_doc": "\nDownload: [https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip](https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip)",
-    "submodules" : [],
-    "type" : "Module"
+    "doc" : "Microphone Mute Toggle and status indicator\n\nDownload: [https:\/\/github.com\/dctucker\/Spoons\/raw\/master\/Spoons\/MicMute.spoon.zip](https:\/\/github.com\/dctucker\/Spoons\/raw\/master\/Spoons\/MicMute.spoon.zip)",
+    "name" : "MicMute"
   }
 ]

--- a/Source/MicMute.spoon/docs.json
+++ b/Source/MicMute.spoon/docs.json
@@ -1,0 +1,39 @@
+[
+  {
+    "Command" : [],
+    "Constant" : [],
+    "Constructor" : [],
+    "Deprecated" : [],
+    "Field" : [],
+    "Function" : [],
+    "Method" : [
+      {
+        "def": "MicMute:toggleMicMute()",
+        "desc": "Toggle mic mute on/off",
+        "doc": "Toggle mic mute on/off",
+        "name": "toggleMicMute",
+        "signature": "MicMute:toggleMicMute()",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "Variable" : [],
+    "desc" : "Microphone Mute Toggle and status indicator",
+    "doc" : "Microphone Mute Toggle and status indicator\n\nDownload: [https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip](https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip)",
+    "items" : [
+      {
+        "def": "MicMute:toggleMicMute()",
+        "desc": "Toggle mic mute on/off",
+        "doc": "Toggle mic mute on/off",
+        "name": "toggleMicMute",
+        "signature": "MicMute:toggleMicMute()",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "name" : "MicMute",
+    "stripped_doc": "\nDownload: [https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip](https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip)",
+    "submodules" : [],
+    "type" : "Module"
+  }
+]

--- a/Source/MicMute.spoon/init.lua
+++ b/Source/MicMute.spoon/init.lua
@@ -1,0 +1,70 @@
+--- === MicMute ===
+---
+--- Microphone Mute Toggle and status indicator
+---
+--- Download: []()
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "MicMute"
+obj.version = "1.0"
+obj.author = "dctucker <dctucker@github.com>"
+obj.homepage = "https://dctucker.com"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+function obj:updateMicMute(muted)
+	if muted == -1 then
+		muted = hs.audiodevice.defaultInputDevice():muted()
+	end
+	if muted then
+		obj.mute_menu:setTitle("📵 Muted")
+	else
+		obj.mute_menu:setTitle("🎙 On")
+	end
+end
+
+function obj:toggleMicMute()
+	local mic = hs.audiodevice.defaultInputDevice()
+	local zoom = hs.application'Zoom'
+	if mic:muted() then
+		mic:setMuted(false)
+		if zoom then
+			local ok = zoom:selectMenuItem'Unmute Audio'
+			if not ok then
+				hs.timer.doAfter(0.5, function()
+					zoom:selectMenuItem'Unmute Audio'
+				end)
+			end
+		end
+	else
+		mic:setMuted(true)
+		if zoom then
+			local ok = zoom:selectMenuItem'Mute Audio'
+			if not ok then
+				hs.timer.doAfter(0.5, function()
+					zoom:selectMenuItem'Mute Audio'
+				end)
+			end
+		end
+	end
+	obj:updateMicMute(-1)
+end
+
+function obj:init()
+	obj.mute_menu = hs.menubar.new()
+	obj.mute_menu:setClickCallback(function()
+		obj:toggleMicMute()
+	end)
+	obj:updateMicMute(-1)
+
+	hs.audiodevice.watcher.setCallback(function(arg)
+		if string.find(arg, "dIn ") then
+			obj:updateMicMute(-1)
+		end
+	end)
+	hs.audiodevice.watcher.start()
+end
+
+return obj

--- a/Source/MicMute.spoon/init.lua
+++ b/Source/MicMute.spoon/init.lua
@@ -2,7 +2,7 @@
 ---
 --- Microphone Mute Toggle and status indicator
 ---
---- Download: []()
+--- Download: [https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip](https://github.com/dctucker/Spoons/raw/master/Spoons/MicMute.spoon.zip)
 
 local obj={}
 obj.__index = obj
@@ -25,6 +25,10 @@ function obj:updateMicMute(muted)
 	end
 end
 
+--- MicMute:toggleMicMute()
+--- Method
+--- Toggle mic mute on/off
+---
 function obj:toggleMicMute()
 	local mic = hs.audiodevice.defaultInputDevice()
 	local zoom = hs.application'Zoom'
@@ -52,7 +56,42 @@ function obj:toggleMicMute()
 	obj:updateMicMute(-1)
 end
 
+--- MicMute:bindHotkeys(mapping, latch_timeout)
+--- Method
+--- Binds hotkeys for MicMute
+---
+--- Parameters:
+---  * mapping - A table containing hotkey modifier/key details for the following items:
+---   * toggle - This will cause the microphone mute status to be toggled. Hold for momentary, press quickly for toggle.
+---  * latch_timeout - Time in seconds to hold the hotkey before momentary mode takes over, in which the mute will be toggled again when hotkey is released. Latch if released before this time. 0.75 for 750 milliseconds is a good value.
+function obj:bindHotkeys(mapping, latch_timeout)
+	if (self.hotkey) then
+		self.hotkey:delete()
+	end
+	local mods = mapping["toggle"][1]
+	local key = mapping["toggle"][2]
+
+	if latch_timeout then
+		self.hotkey = hs.hotkey.bind(mods, key, function()
+			self:toggleMicMute()
+			self.time_since_mute = hs.timer.secondsSinceEpoch()
+		end, function()
+			if hs.timer.secondsSinceEpoch() > self.time_since_mute + latch_timeout then
+				self:toggleMicMute()
+			end
+		end)
+	else
+		self.hotkey = hs.hotkey.bind(mods, key, function()
+			self:toggleMicMute()
+		end)
+	end
+
+	return self
+end
+
+
 function obj:init()
+	obj.time_since_mute = 0
 	obj.mute_menu = hs.menubar.new()
 	obj.mute_menu:setClickCallback(function()
 		obj:toggleMicMute()


### PR DESCRIPTION
For remote workers, it's important to be able to quickly mute and unmute our microhpones when videoconferencing. This spoon adds a menubar item that indicates the muted status of the default input device, and a hotkey with latching and optional momentary action.

Shows <img width="50" alt="image" src="https://user-images.githubusercontent.com/772810/44245027-ba203880-a18b-11e8-989f-4624fe69da89.png"> or <img width="75" alt="image" src="https://user-images.githubusercontent.com/772810/44245033-c1dfdd00-a18b-11e8-83e2-908a09a1d921.png">.

Also toggles the mute status of Zoom, if running.

**Usage:** Add this to your `~/.hammerspoon/init.lua`...
```lua
hs.loadSpoon("MicMute")
spoon.MicMute:bindHotkeys({toggle={{},"F1"}}, 0.75)
```