### PR TITLE
Rename MoveSpaces to get it working with SpoonInstall

### DIFF
--- a/Source/MoveSpaces.spoon/docs.json
+++ b/Source/MoveSpaces.spoon/docs.json
@@ -11,7 +11,7 @@
     "desc": "Move window to the space to the right or left",
     "doc": "Move window to the space to the right or left\n\nMuch of the code was written by Szymon Kaliski <hi@szymonkaliski.com>, converted to spoon by Tyler Thrailkill <tyler.b.thrailkill@gmail.com>\n\nhttps://github.com/snowe2010",
     "items": [],
-    "name": "Move Spaces",
+    "name": "MoveSpaces",
     "stripped_doc": "\nMuch of the code was written by Szymon Kaliski <hi@szymonkaliski.com>, converted to spoon by Tyler Thrailkill <tyler.b.thrailkill@gmail.com>\n\nhttps://github.com/snowe2010",
     "submodules": [],
     "type": "Module"

--- a/Source/MoveSpaces.spoon/init.lua
+++ b/Source/MoveSpaces.spoon/init.lua
@@ -1,4 +1,4 @@
---- === Move Spaces ===
+--- === MoveSpaces ===
 ---
 --- Move window to the space to the right or left
 ---


### PR DESCRIPTION
Right now the MoveSpaces spoon does not work with the SpoonInstall spoon. This is because SpoonInstall uses the “docs/docs.json” file for metadata, and then attempts to download the corresponding .zip file located in the “Spoons” folder.

In the docs.json file for the MoveSpaces spoon, the `name` attribute is set to “Move Spaces”. However, the .zip file for the spoon in the “Spoons” folder is “MoveSpaces.spoon.zip”. This breaks `SpoonInstall:andUse()`.

`spoon.SpoonInstall:andUse("Move Spaces")` finds the spoon in “docs/docs.json” but then tries to find a .zip file named “Move Spaces.spoon.zip” which doesn't exist:
```
2018-08-29 10:33:02: ********
2018-08-29 10:33:02: 10:33:02 ERROR:SpoonInsta: Invalid URL https://github.com/Hammerspoon/Spoons/raw/master/Spoons/Move Spaces.spoon.zip, must point to a zip file
2018-08-29 10:33:02: ********
2018-08-29 10:33:02: ********
2018-08-29 10:33:02: 10:33:02 ERROR:SpoonInsta: Error installing Spoon 'Move Spaces' from repo 'default'
2018-08-29 10:33:02: ********
```

`spoon.SpoonInstall:andUse("MoveSpaces")` fails because there is no spoon with the name “MoveSpaces” in “docs/docs.json”:
```
2018-08-29 10:33:34: ********
2018-08-29 10:33:34: 10:33:34 ERROR:SpoonInsta: Spoon 'MoveSpaces' does not exist in repository 'default'. Please check and try again.
2018-08-29 10:33:34: ********
2018-08-29 10:33:34: ********
2018-08-29 10:33:34: 10:33:34 ERROR:SpoonInsta: Error installing Spoon 'MoveSpaces' from repo 'default'
2018-08-29 10:33:34: ********
```

Since the naming convention for spoons seems to be to use title case (without any spaces). It seems to me like the right way to fix this is to change the `name` attribute to “MoveSpaces” in the spoon's “docs.json” file, which will then flow through to the “docs/docs.json” file.