### PR TITLE
Added space watcher to BingDaily spoon

### DIFF
--- a/Source/BingDaily.spoon/init.lua
+++ b/Source/BingDaily.spoon/init.lua
@@ -16,10 +16,9 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 
 --- BingDaily.changeAllSpaces
 --- Variable
---- If `true` Spoon will set background image to all desktops (spaces).
---- MacOS doesn't have nice API for it, so
---- we're using hack - set watcher to space change and set Bing image to active space
---- Default: false
+--- If `true` Spoon will set background image to all desktops (spaces)
+---
+--- MacOS doesn't have nice API for it, so we're using hack - set watcher to space change and set Bing image to active space. Default: false
 obj.changeAllSpaces = false
 
 -- Path to recently downloaded image from Bing


### PR DESCRIPTION
Hello, @ashfinal @cmsj

I usually use a few desktops, so I've added this small patch to BingDaily spoon

In this PR:
1. added changeAllSpaces variable which allows set background to all desktops
2. moved starting logic from obj:init to obj:start

Unfortunately, to have config variable I need to push logic from obj:init to obj:start
so I've introduced incompatibility. Now users need to call obj:start() to start the Spoon. And maybe it's good idea to introduce this change in global Spoon repository.


