### PR TITLE
Fix download URL and capitalization

### DIFF
--- a/Source/Leanpub.spoon/docs.json
+++ b/Source/Leanpub.spoon/docs.json
@@ -154,7 +154,7 @@
       }
     ],
     "desc": "Spoon to track and notify about Leanpub builds.",
-    "doc": "Spoon to track and notify about Leanpub builds.\n\nDownload:\nhttps://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip",
+    "doc": "Spoon to track and notify about Leanpub builds.\n\nDownload:\nhttps://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip",
     "items": [
       {
         "def": "Leanpub.api_key",
@@ -301,7 +301,7 @@
       }
     ],
     "name": "Leanpub",
-    "stripped_doc": "\nDownload:\nhttps://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip",
+    "stripped_doc": "\nDownload:\nhttps://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip",
     "submodules": [],
     "type": "Module"
   }

--- a/Source/Leanpub.spoon/docs.json
+++ b/Source/Leanpub.spoon/docs.json
@@ -19,7 +19,7 @@
       {
         "def": "Leanpub:displayBookStatus(book)",
         "desc": "Display a notification with the current build status of a book.",
-        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from LeanPub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
+        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from Leanpub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
         "name": "displayBookStatus",
         "parameters": [
           " * book - table containing the information of the book to",
@@ -29,7 +29,7 @@
           "   * icon - optional icon to show in the notifications for the",
           "     book, as an `hs.image` object. If this field is not specified",
           "     but `fetch_leanpub_covers` is true (the default value), this",
-          "     method attempts to fetch the book cover from LeanPub. If the",
+          "     method attempts to fetch the book cover from Leanpub. If the",
           "     cover can be retrieved, it gets stored in the icon field so",
           "     it doesn't get fetched every time. You can disable cover",
           "     fetching for individual books by setting this field",
@@ -186,7 +186,7 @@
       {
         "def": "Leanpub:displayBookStatus(book)",
         "desc": "Display a notification with the current build status of a book.",
-        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from LeanPub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
+        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from Leanpub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
         "name": "displayBookStatus",
         "parameters": [
           " * book - table containing the information of the book to",
@@ -196,7 +196,7 @@
           "   * icon - optional icon to show in the notifications for the",
           "     book, as an `hs.image` object. If this field is not specified",
           "     but `fetch_leanpub_covers` is true (the default value), this",
-          "     method attempts to fetch the book cover from LeanPub. If the",
+          "     method attempts to fetch the book cover from Leanpub. If the",
           "     cover can be retrieved, it gets stored in the icon field so",
           "     it doesn't get fetched every time. You can disable cover",
           "     fetching for individual books by setting this field",

--- a/Source/Leanpub.spoon/init.lua
+++ b/Source/Leanpub.spoon/init.lua
@@ -111,7 +111,7 @@ obj.last_status = {}
 ---    * icon - optional icon to show in the notifications for the
 ---      book, as an `hs.image` object. If this field is not specified
 ---      but `fetch_leanpub_covers` is true (the default value), this
----      method attempts to fetch the book cover from LeanPub. If the
+---      method attempts to fetch the book cover from Leanpub. If the
 ---      cover can be retrieved, it gets stored in the icon field so
 ---      it doesn't get fetched every time. You can disable cover
 ---      fetching for individual books by setting this field

--- a/Source/Leanpub.spoon/init.lua
+++ b/Source/Leanpub.spoon/init.lua
@@ -3,7 +3,7 @@
 --- Spoon to track and notify about Leanpub builds.
 ---
 --- Download:
---- https://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip
+--- https://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip
 
 local obj={}
 obj.__index = obj

--- a/docs/Leanpub.html
+++ b/docs/Leanpub.html
@@ -224,7 +224,7 @@ of the book URL after <a href="https://leanpub.com/">https://leanpub.com/</a>.</
 <li>icon - optional icon to show in the notifications for the
 book, as an <code>hs.image</code> object. If this field is not specified
 but <code>fetch_leanpub_covers</code> is true (the default value), this
-method attempts to fetch the book cover from LeanPub. If the
+method attempts to fetch the book cover from Leanpub. If the
 cover can be retrieved, it gets stored in the icon field so
 it doesn't get fetched every time. You can disable cover
 fetching for individual books by setting this field

--- a/docs/Leanpub.html
+++ b/docs/Leanpub.html
@@ -17,7 +17,7 @@
       <h1><a href="./index.html">docs</a> &raquo; Leanpub</h1>
       <p>Spoon to track and notify about Leanpub builds.</p>
 <p>Download:
-<a href="https://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip">https://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip</a></p>
+<a href="https://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip">https://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip</a></p>
 
       </header>
       <h3>API Overview</h3>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2843,7 +2843,7 @@
       {
         "def": "Leanpub:displayBookStatus(book)",
         "desc": "Display a notification with the current build status of a book.",
-        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from LeanPub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
+        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from Leanpub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
         "name": "displayBookStatus",
         "parameters": [
           " * book - table containing the information of the book to",
@@ -2853,7 +2853,7 @@
           "   * icon - optional icon to show in the notifications for the",
           "     book, as an `hs.image` object. If this field is not specified",
           "     but `fetch_leanpub_covers` is true (the default value), this",
-          "     method attempts to fetch the book cover from LeanPub. If the",
+          "     method attempts to fetch the book cover from Leanpub. If the",
           "     cover can be retrieved, it gets stored in the icon field so",
           "     it doesn't get fetched every time. You can disable cover",
           "     fetching for individual books by setting this field",
@@ -3010,7 +3010,7 @@
       {
         "def": "Leanpub:displayBookStatus(book)",
         "desc": "Display a notification with the current build status of a book.",
-        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from LeanPub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
+        "doc": "Display a notification with the current build status of a book.\nOnly produce a notification if the current status is different\nthan the last known one (from the last time `displayBookStatus`\nwas run for the same book).\n\nParameters:\n * book - table containing the information of the book to\n   check. The table must contain the following fields:\n   * slug - URL \"slug\" of the book to check. The slug is the part\n     of the book URL after https://leanpub.com/.\n   * icon - optional icon to show in the notifications for the\n     book, as an `hs.image` object. If this field is not specified\n     but `fetch_leanpub_covers` is true (the default value), this\n     method attempts to fetch the book cover from Leanpub. If the\n     cover can be retrieved, it gets stored in the icon field so\n     it doesn't get fetched every time. You can disable cover\n     fetching for individual books by setting this field\n     explicitly to `false`\n\nReturns:\n * A Lua table containing the status (may be empty), nil if an\n   error occurred",
         "name": "displayBookStatus",
         "parameters": [
           " * book - table containing the information of the book to",
@@ -3020,7 +3020,7 @@
           "   * icon - optional icon to show in the notifications for the",
           "     book, as an `hs.image` object. If this field is not specified",
           "     but `fetch_leanpub_covers` is true (the default value), this",
-          "     method attempts to fetch the book cover from LeanPub. If the",
+          "     method attempts to fetch the book cover from Leanpub. If the",
           "     cover can be retrieved, it gets stored in the icon field so",
           "     it doesn't get fetched every time. You can disable cover",
           "     fetching for individual books by setting this field",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2978,7 +2978,7 @@
       }
     ],
     "desc": "Spoon to track and notify about Leanpub builds.",
-    "doc": "Spoon to track and notify about Leanpub builds.\n\nDownload:\nhttps://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip",
+    "doc": "Spoon to track and notify about Leanpub builds.\n\nDownload:\nhttps://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip",
     "items": [
       {
         "def": "Leanpub.api_key",
@@ -3125,7 +3125,7 @@
       }
     ],
     "name": "Leanpub",
-    "stripped_doc": "\nDownload:\nhttps://github.com/zzamboni/zzSpoons/raw/master/Spoons/Leanpub.spoon.zip",
+    "stripped_doc": "\nDownload:\nhttps://github.com/Hammerspoon/Spoons/raw/master/Spoons/Leanpub.spoon.zip",
     "submodules": [],
     "type": "Module"
   },


### PR DESCRIPTION
- Fix download URL to the main Spoons repository.
- Fix "LeanPub" to "Leanpub" (which is the official spelling of the name).