### PR TITLE
TimeMachineProgress: clean up infinite tempfiles

### DIFF
--- a/Source/TimeMachineProgress.spoon/init.lua
+++ b/Source/TimeMachineProgress.spoon/init.lua
@@ -98,6 +98,7 @@ function obj:refresh()
   f:write(out)
   f:close()
   data = hs.plist.read(outfile)
+  os.remove(outfile)
   self.logger.df("formatted data read by hs.plist: %s\n", hs.inspect(data))
 
   if data['Running'] == '1' then

--- a/Source/TimeMachineProgress.spoon/init.lua
+++ b/Source/TimeMachineProgress.spoon/init.lua
@@ -93,7 +93,7 @@ function obj:refresh()
   end
   self.logger.df("tmutil status output: %s\n", out)
   -- Write output to a file and read it using hs.plist
-  local outfile = hs.execute("/usr/bin/mktemp")
+  local outfile = hs.execute("/usr/bin/mktemp"):match( "^%s*(.-)%s*$" )
   local f = assert(io.open(outfile, "w"))
   f:write(out)
   f:close()


### PR DESCRIPTION
The TimeMachineProgress spoon creates two tempfiles every second.

The first is a normal `tmp.xxyyzz` and the second is `tmp.xxyyzz\n`.

Neither tempfile gets cleaned up.

This patch fixes both issues for the "sunny day" case.