### PR TITLE
Fix app icon for seal_apps and initial state for pasteboard

### DIFF
--- a/Source/Seal.spoon/seal_apps.lua
+++ b/Source/Seal.spoon/seal_apps.lua
@@ -30,6 +30,9 @@ local modifyNameMap = function(info, add)
       end
       if add then
          bundleID = item.kMDItemCFBundleIdentifier
+         if (not icon) and (bundleID) then
+           icon = hs.image.imageFromAppBundle(bundleID)
+         end
          obj.appCache[displayname] = {
             path = item.kMDItemPath,
             bundleID = bundleID,

--- a/Source/Seal.spoon/seal_pasteboard.lua
+++ b/Source/Seal.spoon/seal_pasteboard.lua
@@ -65,7 +65,7 @@ function obj.checkPasteboard()
     local pasteboard = hs.pasteboard.getContents()
     local shouldSave = false
     -- FIXME: Filter out things with UTIs documented at http://nspasteboard.org/
-    if pasteboard ~= obj.itemBuffer[#obj.itemBuffer]["text"] then
+    if (#obj.itemBuffer == 0) or (pasteboard ~= obj.itemBuffer[#obj.itemBuffer]["text"]) then
         local currentTypes = hs.pasteboard.allContentTypes()[1]
         for _,aType in pairs(currentTypes) do
             for _,uti in pairs({"de.petermaurer.TransientPasteboardType",


### PR DESCRIPTION
1. Fix in some cases seal_apps can't get the correct icon. 
2. fix pasteboard crashing when the buffer is empty, 