### PR TITLE
HSKeybindings uses undefined inspect in print

### DIFF
--- a/Source/HSKeybindings.spoon/init.lua
+++ b/Source/HSKeybindings.spoon/init.lua
@@ -51,7 +51,7 @@ end
 --]] 
 
 local function getModifiers(modslist)
-  print("getModifiers:" .. inspect(mods))
+  --print("getModifiers:" .. inspect(mods))
   local mods = ''
   for ix, val in ipairs(modslist) do
     mods = mods .. obj.commandEnum[val]
@@ -73,7 +73,7 @@ local function processHotkeys()
     end
   end
 
-  print(inspect(allKeys))
+  --print(inspect(allKeys))
 
   for ix, entry in ipairs(allKeys) do
     if ((ix - 1) % 15) == 0 then


### PR DESCRIPTION
Why:

 * when trying out hskeybindings I got an error referring
   to undefined inspect call.

This change addreses the need by:

 * comment out the dubious print(inspect statements.