### PR TITLE
WinWin - Fix "fullscreen". Add Maximize/Minimize options

### DIFF
--- a/Source/WinWin.spoon/docs.json
+++ b/Source/WinWin.spoon/docs.json
@@ -19,7 +19,7 @@
       {
         "def": "WinWin:moveAndResize(option)",
         "desc": "Move and resize the focused window.",
-        "doc": "Move and resize the focused window.\n\nParameters:\n * option - A string specifying the option, valid strings are: `halfleft`, `halfright`, `halfup`, `halfdown`, `cornerNW`, `cornerSW`, `cornerNE`, `cornerSE`, `center`, `fullscreen`, `expand`, `shrink`.",
+        "doc": "Move and resize the focused window.\n\nParameters:\n * option - A string specifying the option, valid strings are: `halfleft`, `halfright`, `halfup`, `halfdown`, `cornerNW`, `cornerSW`, `cornerNE`, `cornerSE`, `center`, `fullscreen`, `maximize`, `minimize`, `expand`, `shrink`.",
         "name": "moveAndResize",
         "parameters": [
           " * option - A string specifying the option, valid strings are: `halfleft`, `halfright`, `halfup`, `halfdown`, `cornerNW`, `cornerSW`, `cornerNE`, `cornerSE`, `center`, `fullscreen`, `expand`, `shrink`."

--- a/Source/WinWin.spoon/init.lua
+++ b/Source/WinWin.spoon/init.lua
@@ -134,6 +134,18 @@ function obj:moveAndResize(option)
         elseif option == "fullscreen" then
             windowStash(cwin)
             cwin:setFrame({x=cres.x, y=cres.y, w=cres.w, h=cres.h})
+        elseif option == "maximize" then
+            windowStash(cwin)
+            cwin:maximize()
+        elseif option == "minimize" then
+            if cwin:isFullScreen() then
+                cwin:setFullScreen(false)
+                -- required to let the window manager register the new state,
+                -- otherwise the follow-up minimize() call doesn't work
+                hs.timer.usleep(999999)
+            end
+            windowStash(cwin)
+            cwin:minimize()
         elseif option == "center" then
             windowStash(cwin)
             cwin:centerOnScreen()

--- a/Source/WinWin.spoon/init.lua
+++ b/Source/WinWin.spoon/init.lua
@@ -133,7 +133,7 @@ function obj:moveAndResize(option)
             cwin:setFrame({x=cres.x+cres.w/2, y=cres.y+cres.h/2, w=cres.w/2, h=cres.h/2})
         elseif option == "fullscreen" then
             windowStash(cwin)
-            cwin:setFrame({x=cres.x, y=cres.y, w=cres.w, h=cres.h})
+            cwin:setFullScreen(true)
         elseif option == "maximize" then
             windowStash(cwin)
             cwin:maximize()

--- a/Source/WinWin.spoon/init.lua
+++ b/Source/WinWin.spoon/init.lua
@@ -123,7 +123,7 @@ function obj:moveAndResize(option)
             expand = function() cwin:setFrame({x=wf.x-stepw, y=wf.y-steph, w=wf.w+(stepw*2), h=wf.h+(steph*2)}) end,
             shrink = function() cwin:setFrame({x=wf.x+stepw, y=wf.y+steph, w=wf.w-(stepw*2), h=wf.h-(steph*2)}) end,
         }
-        if not (options[option] ~= nil) then
+        if options[option] == nil then
             hs.alert.show("Unknown option: " .. option)
         else
             -- if the window is fullscreen, and that's not what the user wants,


### PR DESCRIPTION
This PR seeks to make "fullscreen" consistent with other notions of "fullscreen", and add maximize/minimize options instead.

I do expect my "fullscreen" change to be contentious, but given the chosen name and behavior, I'm not sure how to get around that and be "backwards compatible".