### PR TITLE
Download Retina-resolution images in UnsplashRandom

### DIFF
--- a/Source/UnsplashRandom.spoon/init.lua
+++ b/Source/UnsplashRandom.spoon/init.lua
@@ -30,7 +30,9 @@ local function unsplashRequest()
     end
     obj.localpath = os.getenv("HOME") .. "/.Trash/".. hs.hash.SHA1(hs.timer.absoluteTime()) .. ".jpg"
     local screen_data = hs.screen.mainScreen():currentMode()
-    local image_url = "https://source.unsplash.com/random/" .. screen_data["w"]  .. "x" .. screen_data["h"]
+    local width = string.format("%0.f", screen_data.w * screen_data.scale)
+    local height = string.format("%0.f", screen_data.h * screen_data.scale)
+    local image_url = "https://source.unsplash.com/random/" .. width .. "x" .. height
     obj.task = hs.task.new("/usr/bin/curl", curl_callback, {"-L", image_url, "-o", obj.localpath})
     obj.task:start()
 end


### PR DESCRIPTION
UnsplashRandom images are blurry on Retina displays. This fixes the spoon to take into account the display scale factor (2.0 on Retina displays).