### PR TITLE
Support new "Archive" menu option in newer versions of Outlook

### DIFF
--- a/Source/UniversalArchive.spoon/init.lua
+++ b/Source/UniversalArchive.spoon/init.lua
@@ -119,18 +119,21 @@ end
 
 --- UniversalArchive:outlookArchive()
 --- Method
---- Archive current message in Outlook to the folder specified in
---- `UniversalArchive.outlook_archive_folder`. The folder has to
---- appear in the Message -> Move submenu for this to work. Since this
---- submenu only lists the last few destination folders, you have to
---- move a message by hand the first time (or periodically if you
---- don't archive very often).
+--- Archive current message in Outlook using one of two methods:
+--- 1. If the "Message -> Archive" menu item exists, it is used (this
+---    has been added in recent versions of Outlook)
+--- 2. Otherwise, the message gets manually moved to the folder
+---    specified in `UniversalArchive.outlook_archive_folder`. The folder
+---    has to appear in the Message -> Move submenu for this to
+---    work. Since this submenu only lists the last few destination
+---    folders, you have to move a message by hand the first time (or
+---    periodically if you don't archive very often).
 ---
 --- Parameters:
 ---  * none
 function obj:outlookArchive()
    local outlook = hs.appfinder.appFromName("Microsoft Outlook")
-   if outlook:selectMenuItem({"Message", "Move", self.outlook_archive_folder}) then
+   if outlook:selectMenuItem({"Message", "Archive"}) or outlook:selectMenuItem({"Message", "Move", self.outlook_archive_folder}) then
       if self.archive_notifications then
          hs.notify.show("Outlook", "", "Archiving message")
       end


### PR DESCRIPTION
Archive current message in Outlook using one of two methods:


1. If the "Message -> Archive" menu item exists, it is used (this has been added in recent versions of Outlook)
2. Otherwise, the message gets manually moved to the folder   specified in `UniversalArchive.outlook_archive_folder`. The folder   has to appear in the Message -> Move submenu for this to   work. Since this submenu only lists the last few destination   folders, you have to move a message by hand the first time (or   periodically if you don't archive very often).