### PR TITLE
Update TimeMachineProgress spoon for new tmutil output format

### DIFF
--- a/Source/TimeMachineProgress.spoon/init.lua
+++ b/Source/TimeMachineProgress.spoon/init.lua
@@ -108,6 +108,7 @@ function obj:refresh()
       self.menuBarItem:setIcon(self.backupIcon, false)
     end
     title = nil
+    if (data['Progress']) then data = data['Progress'] end
     if (data['Percent'] == '-1' or data['Percent'] == '0') then
       title = "(prep)"
     else


### PR DESCRIPTION
At some point (maybe in Catalina) the format emitted by tmutil changes to have the progress fields inside a 'Progress' map. This patch makes it possible to process this new format (retaining compatibility with the previous one).