### PR TITLE
Add Seal.queryChangedTimerDuration variable

### DIFF
--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -33,6 +33,12 @@ obj.queryChangedTimer = nil
 
 obj.spoonPath = hs.spoons.scriptPath()
 
+--- Seal.queryChangedTimerDuration
+--- Variable
+--- Time between the last keystroke and the start of the recalculation of the choices to display, in seconds.
+--- Defaults to 0.02s (20ms).
+obj.queryChangedTimerDuration = 0.02
+
 --- Seal.plugin_search_paths
 --- Variable
 --- List of directories where Seal will look for plugins. Defaults to `~/.hammerspoon/seal_plugins/` and the Seal Spoon directory.
@@ -334,7 +340,8 @@ function obj.queryChangedCallback(query)
     if obj.queryChangedTimer then
         obj.queryChangedTimer:stop()
     end
-    obj.queryChangedTimer = hs.timer.doAfter(0.2, function() obj.chooser:refreshChoicesCallback() end)
+    obj.queryChangedTimer = hs.timer.doAfter(obj.queryChangedTimerDuration,
+                                             function() obj.chooser:refreshChoicesCallback() end)
 end
 
 return obj


### PR DESCRIPTION
The default timer in Seal of 200ms before recomputing the results feels very unreponsive compared to popular apps like Alfred. I understand that some applications might warrant it, but a timer duration of zero has been fine with my usage. I added it as a configurable variable and changed the default to 20ms, although there's no reason it couldn't be something different; its being easily configurable is most important.