### PR TITLE
Catch a nil

### DIFF
--- a/Source/Seal.spoon/seal_safari_bookmarks.lua
+++ b/Source/Seal.spoon/seal_safari_bookmarks.lua
@@ -61,7 +61,7 @@ function obj.choicesBookmarks(query)
     end
     for name,bookmark in pairs(obj.bookmarkCache) do
         url = bookmark["url"]
-        if string.match(name:lower(), query:lower()) or string.match(url:lower(), query:lower()) then
+        if url and (string.match(name:lower(), query:lower()) or string.match(url:lower(), query:lower())) then
             local choice = {}
             local instances = {}
             choice["text"] = name


### PR DESCRIPTION
Fixes

```
2020-05-03 09:41:51: ********
2020-05-03 09:41:51: 09:41:51 ERROR:   LuaSkin: hs.chooser:choices error - ...hammerspoon/Spoons/Seal.spoon//seal_safari_bookmarks.lua:64: attempt to index a nil value (global 'url')
stack traceback:
	...hammerspoon/Spoons/Seal.spoon//seal_safari_bookmarks.lua:64: in function 'bare'
	...manpreets/.config/hammerspoon/Spoons/Seal.spoon/init.lua:313: in function 'Seal.choicesCallback'
	[C]: in method 'refreshChoicesCallback'
	...manpreets/.config/hammerspoon/Spoons/Seal.spoon/init.lua:337: in function <...manpreets/.config/hammerspoon/Spoons/Seal.spoon/init.lua:337>
2020-05-03 09:41:51: ********
```