### PR TITLE
PushToTalk: Detect running apps on start

### DIFF
--- a/Source/PushToTalk.spoon/docs.json
+++ b/Source/PushToTalk.spoon/docs.json
@@ -47,6 +47,15 @@
         "signature": "PushToTalk.app_switcher",
         "stripped_doc": "For example this `{ ['zoom.us'] = 'push-to-talk' }` will switch mic to `push-to-talk` state when Zoom app starts.",
         "type": "Variable"
+      },
+      {
+        "def": "PushToTalk.detect_on_start",
+        "desc": "Check running applications when starting PushToTalk.",
+        "doc": "Check running applications when starting PushToTalk.\nDefaults to false for backwards compatibility. With this disabled, PushToTalk will only change state when applications are launched or quit while PushToTalk is already active. Enable this to look through list of running applications when PushToTalk is started. If multiple apps defined in app_switcher are running, it will set state to the first one it encounters.",
+        "name": "detect_on_start",
+        "signature": "PushToTalk.detect_on_start",
+        "stripped_doc": "Defaults to false for backwards compatibility. With this disabled, PushToTalk will only change state when applications are launched or quit while PushToTalk is already active. Enable this to look through list of running applications when PushToTalk is started. If multiple apps defined in app_switcher are running, it will set state to the first one it encounters.",
+        "type": "Variable"
       }
     ],
     "desc": "Implements push-to-talk and push-to-mute functionality with `fn` key.",


### PR DESCRIPTION
PushToTalk only changes state based on running applications if they are
launched or quit after PushToTalk has already been started. So if any
targeted apps are running when PushToTalk itself is started, or
Hammerspoon reloaded, it will not automatically set the microphone
state.

This add a disabled by default option to check the list of running
applications when starting PushToTalk, so relaunching or reloading
Hammerspoon will typically get you back to the desired state, instead
of default state regardless of what apps are running or not.

The `initialState()` function is optimistic, in that it will use the
configured state for whichever application from `app_switcher` it
encounters first, so for complex configurations, a relaunch/reload of
Hammerspoon might not set the microphone state back to what it
originally was.