### PR TITLE
New spoon TurboBoost

### DIFF
--- a/Source/TurboBoost.spoon/docs.json
+++ b/Source/TurboBoost.spoon/docs.json
@@ -1,0 +1,738 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+      {
+        "name" : "logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.logger",
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+      },
+      {
+        "name" : "disable_on_start",
+        "stripped_doc" : [
+          "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false."
+        ],
+        "doc" : "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.disable_on_start",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.disable_on_start",
+        "desc" : "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false."
+      },
+      {
+        "name" : "reenable_on_stop",
+        "stripped_doc" : [
+          "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true."
+        ],
+        "doc" : "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.reenable_on_stop",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.reenable_on_stop",
+        "desc" : "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true."
+      },
+      {
+        "name" : "kext_path",
+        "stripped_doc" : [
+          "Where the DisableTurboBoost.kext file is located."
+        ],
+        "doc" : "Where the DisableTurboBoost.kext file is located.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.kext_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.kext_path",
+        "desc" : "Where the DisableTurboBoost.kext file is located."
+      },
+      {
+        "name" : "load_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to load the DisableTurboBoost kernel",
+          "extension. This command must execute with root privileges and",
+          "either query the user for the credentials, or be configured",
+          "(e.g. with sudo) to run without prompting. The string \"%s\" in this",
+          "variable gets replaced with the value of",
+          "TurboBoost.kext_path"
+        ],
+        "doc" : "Command to execute to load the DisableTurboBoost kernel\nextension. This command must execute with root privileges and\neither query the user for the credentials, or be configured\n(e.g. with sudo) to run without prompting. The string \"%s\" in this\nvariable gets replaced with the value of\nTurboBoost.kext_path",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.load_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.load_kext_cmd",
+        "desc" : "Command to execute to load the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "unload_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to unload the DisableTurboBoost kernel",
+          "extension. This command must execute with root privileges and",
+          "either query the user for the credentials, or be configured",
+          "(e.g. with sudo) to run without prompting. The string \"%s\" in this",
+          "variable gets replaced with the value of",
+          "TurboBoost.kext_path"
+        ],
+        "doc" : "Command to execute to unload the DisableTurboBoost kernel\nextension. This command must execute with root privileges and\neither query the user for the credentials, or be configured\n(e.g. with sudo) to run without prompting. The string \"%s\" in this\nvariable gets replaced with the value of\nTurboBoost.kext_path",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.unload_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.unload_kext_cmd",
+        "desc" : "Command to execute to unload the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "check_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to check whether the DisableTurboBoost kernel",
+          "extension is loaded."
+        ],
+        "doc" : "Command to execute to check whether the DisableTurboBoost kernel\nextension is loaded.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.check_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.check_kext_cmd",
+        "desc" : "Command to execute to check whether the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "notify",
+        "stripped_doc" : [
+          "Boolean indicating whether notifications should be generated when",
+          "Turbo Boost is enabled\/disabled."
+        ],
+        "doc" : "Boolean indicating whether notifications should be generated when\nTurbo Boost is enabled\/disabled.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.notify",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.notify",
+        "desc" : "Boolean indicating whether notifications should be generated when"
+      },
+      {
+        "name" : "enabled_icon_path",
+        "stripped_doc" : [
+          "Where to find the icon to use for the \"Enabled\" icon. Defaults to",
+          "using the one from the Turbo Boost application."
+        ],
+        "doc" : "Where to find the icon to use for the \"Enabled\" icon. Defaults to\nusing the one from the Turbo Boost application.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.enabled_icon_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.enabled_icon_path",
+        "desc" : "Where to find the icon to use for the \"Enabled\" icon. Defaults to"
+      },
+      {
+        "name" : "disabled_icon_path",
+        "stripped_doc" : [
+          "Where to find the icon to use for the \"Disabled\" icon. Defaults to",
+          "using the one from the Turbo Boost application."
+        ],
+        "doc" : "Where to find the icon to use for the \"Disabled\" icon. Defaults to\nusing the one from the Turbo Boost application.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.disabled_icon_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.disabled_icon_path",
+        "desc" : "Where to find the icon to use for the \"Disabled\" icon. Defaults to"
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "desc" : "A spoon to load\/unload the Turbo Boost Disable kernel extension",
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "Constructor" : [
+
+    ],
+    "Field" : [
+
+    ],
+    "items" : [
+      {
+        "name" : "check_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to check whether the DisableTurboBoost kernel",
+          "extension is loaded."
+        ],
+        "doc" : "Command to execute to check whether the DisableTurboBoost kernel\nextension is loaded.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.check_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.check_kext_cmd",
+        "desc" : "Command to execute to check whether the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "disable_on_start",
+        "stripped_doc" : [
+          "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false."
+        ],
+        "doc" : "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.disable_on_start",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.disable_on_start",
+        "desc" : "Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false."
+      },
+      {
+        "name" : "disabled_icon_path",
+        "stripped_doc" : [
+          "Where to find the icon to use for the \"Disabled\" icon. Defaults to",
+          "using the one from the Turbo Boost application."
+        ],
+        "doc" : "Where to find the icon to use for the \"Disabled\" icon. Defaults to\nusing the one from the Turbo Boost application.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.disabled_icon_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.disabled_icon_path",
+        "desc" : "Where to find the icon to use for the \"Disabled\" icon. Defaults to"
+      },
+      {
+        "name" : "enabled_icon_path",
+        "stripped_doc" : [
+          "Where to find the icon to use for the \"Enabled\" icon. Defaults to",
+          "using the one from the Turbo Boost application."
+        ],
+        "doc" : "Where to find the icon to use for the \"Enabled\" icon. Defaults to\nusing the one from the Turbo Boost application.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.enabled_icon_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.enabled_icon_path",
+        "desc" : "Where to find the icon to use for the \"Enabled\" icon. Defaults to"
+      },
+      {
+        "name" : "kext_path",
+        "stripped_doc" : [
+          "Where the DisableTurboBoost.kext file is located."
+        ],
+        "doc" : "Where the DisableTurboBoost.kext file is located.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.kext_path",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.kext_path",
+        "desc" : "Where the DisableTurboBoost.kext file is located."
+      },
+      {
+        "name" : "load_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to load the DisableTurboBoost kernel",
+          "extension. This command must execute with root privileges and",
+          "either query the user for the credentials, or be configured",
+          "(e.g. with sudo) to run without prompting. The string \"%s\" in this",
+          "variable gets replaced with the value of",
+          "TurboBoost.kext_path"
+        ],
+        "doc" : "Command to execute to load the DisableTurboBoost kernel\nextension. This command must execute with root privileges and\neither query the user for the credentials, or be configured\n(e.g. with sudo) to run without prompting. The string \"%s\" in this\nvariable gets replaced with the value of\nTurboBoost.kext_path",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.load_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.load_kext_cmd",
+        "desc" : "Command to execute to load the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.logger",
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+      },
+      {
+        "name" : "notify",
+        "stripped_doc" : [
+          "Boolean indicating whether notifications should be generated when",
+          "Turbo Boost is enabled\/disabled."
+        ],
+        "doc" : "Boolean indicating whether notifications should be generated when\nTurbo Boost is enabled\/disabled.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.notify",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.notify",
+        "desc" : "Boolean indicating whether notifications should be generated when"
+      },
+      {
+        "name" : "reenable_on_stop",
+        "stripped_doc" : [
+          "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true."
+        ],
+        "doc" : "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.reenable_on_stop",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.reenable_on_stop",
+        "desc" : "Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true."
+      },
+      {
+        "name" : "unload_kext_cmd",
+        "stripped_doc" : [
+          "Command to execute to unload the DisableTurboBoost kernel",
+          "extension. This command must execute with root privileges and",
+          "either query the user for the credentials, or be configured",
+          "(e.g. with sudo) to run without prompting. The string \"%s\" in this",
+          "variable gets replaced with the value of",
+          "TurboBoost.kext_path"
+        ],
+        "doc" : "Command to execute to unload the DisableTurboBoost kernel\nextension. This command must execute with root privileges and\neither query the user for the credentials, or be configured\n(e.g. with sudo) to run without prompting. The string \"%s\" in this\nvariable gets replaced with the value of\nTurboBoost.kext_path",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost.unload_kext_cmd",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost.unload_kext_cmd",
+        "desc" : "Command to execute to unload the DisableTurboBoost kernel"
+      },
+      {
+        "name" : "bindHotkeys",
+        "stripped_doc" : [
+          "Binds hotkeys for TurboBoost",
+          ""
+        ],
+        "doc" : "Binds hotkeys for TurboBoost\n\nParameters:\n * mapping - A table containing hotkey objifier\/key details for the following items:\n  * hello - Say Hello",
+        "parameters" : [
+          " * mapping - A table containing hotkey objifier\/key details for the following items:",
+          "  * hello - Say Hello"
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost:bindHotkeys(mapping)",
+        "desc" : "Binds hotkeys for TurboBoost"
+      },
+      {
+        "name" : "setState",
+        "stripped_doc" : [
+          "Sets whether Turbo Boost should be disabled (kernel extension",
+          "loaded) or enabled (normal state, kernel extension not loaded).",
+          ""
+        ],
+        "doc" : "Sets whether Turbo Boost should be disabled (kernel extension\nloaded) or enabled (normal state, kernel extension not loaded).\n\nParameters:\n * state - A boolean, false if Turbo Boost should be disabled\n   (load kernel extension), true if it should be enabled (unload\n   kernel extension if loaded).\n * notify - Optional boolean indicating whether a notification\n   should be produced. If not given, the value of\n   TurboBoost.notify is used.\n\nReturns:\n * Boolean indicating new state",
+        "parameters" : [
+          " * state - A boolean, false if Turbo Boost should be disabled",
+          "   (load kernel extension), true if it should be enabled (unload",
+          "   kernel extension if loaded).",
+          " * notify - Optional boolean indicating whether a notification",
+          "   should be produced. If not given, the value of",
+          "   TurboBoost.notify is used.",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:setState(state)",
+        "type" : "Method",
+        "returns" : [
+          " * Boolean indicating new state"
+        ],
+        "def" : "TurboBoost:setState(state)",
+        "desc" : "Sets whether Turbo Boost should be disabled (kernel extension"
+      },
+      {
+        "name" : "start",
+        "stripped_doc" : [
+          "Starts TurboBoost",
+          ""
+        ],
+        "doc" : "Starts TurboBoost\n\nParameters:\n * None\n\nReturns:\n * The TurboBoost object",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:start()",
+        "type" : "Method",
+        "returns" : [
+          " * The TurboBoost object"
+        ],
+        "def" : "TurboBoost:start()",
+        "desc" : "Starts TurboBoost"
+      },
+      {
+        "name" : "status",
+        "stripped_doc" : [
+          "Check whether Turbo Boost is enabled",
+          ""
+        ],
+        "doc" : "Check whether Turbo Boost is enabled\n\nReturns:\n * true if TurboBoost is enabled (kernel ext not loaded), false otherwise.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:status()",
+        "type" : "Method",
+        "returns" : [
+          " * true if TurboBoost is enabled (kernel ext not loaded), false otherwise."
+        ],
+        "def" : "TurboBoost:status()",
+        "desc" : "Check whether Turbo Boost is enabled"
+      },
+      {
+        "name" : "stop",
+        "stripped_doc" : [
+          "Stops TurboBoost",
+          ""
+        ],
+        "doc" : "Stops TurboBoost\n\nParameters:\n * None\n\nReturns:\n * The TurboBoost object",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * The TurboBoost object"
+        ],
+        "def" : "TurboBoost:stop()",
+        "desc" : "Stops TurboBoost"
+      },
+      {
+        "name" : "toggle",
+        "stripped_doc" : [
+          "Toggle TurboBoost status",
+          ""
+        ],
+        "doc" : "Toggle TurboBoost status\n\nReturns:\n * New TurboBoost status, after the toggle",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:toggle()",
+        "type" : "Method",
+        "returns" : [
+          " * New TurboBoost status, after the toggle"
+        ],
+        "def" : "TurboBoost:toggle()",
+        "desc" : "Toggle TurboBoost status"
+      }
+    ],
+    "Command" : [
+
+    ],
+    "doc" : "A spoon to load\/unload the Turbo Boost Disable kernel extension\nfrom https:\/\/github.com\/rugarciap\/Turbo-Boost-Switcher.\n\nNote: this spoon by default uses sudo to load\/unload the kernel\nextension, so for it to work from Hammerspoon, you need to\nconfigure sudo to be able to load\/unload the extension without a\npassword, or configure the load_kext_cmd and unload_kext_cmd\nvariables to use some other mechanism that prompts you for the\ncredentials.\n\nFor example, the following configuration (stored in\n\/etc\/sudoers.d\/turboboost) can be used to allow loading and\nunloading the module without a password:\n```\nCmnd_Alias    TURBO_OPS = \/sbin\/kextunload \/Applications\/Turbo Boost Switcher.app\/Contents\/Resources\/DisableTurboBoost.64bits.kext, \/usr\/bin\/kextutil \/Applications\/Turbo Boost Switcher.app\/Contents\/Resources\/DisableTurboBoost.64bits.kext\n\n%admin ALL=(ALL) NOPASSWD: TURBO_OPS\n```\n\nIf you use this, please support the author of Turbo Boost Disabler\nby purchasing the Pro version of the app!\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/TurboBoost.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/TurboBoost.spoon.zip)",
+    "Method" : [
+      {
+        "name" : "setState",
+        "stripped_doc" : [
+          "Sets whether Turbo Boost should be disabled (kernel extension",
+          "loaded) or enabled (normal state, kernel extension not loaded).",
+          ""
+        ],
+        "doc" : "Sets whether Turbo Boost should be disabled (kernel extension\nloaded) or enabled (normal state, kernel extension not loaded).\n\nParameters:\n * state - A boolean, false if Turbo Boost should be disabled\n   (load kernel extension), true if it should be enabled (unload\n   kernel extension if loaded).\n * notify - Optional boolean indicating whether a notification\n   should be produced. If not given, the value of\n   TurboBoost.notify is used.\n\nReturns:\n * Boolean indicating new state",
+        "parameters" : [
+          " * state - A boolean, false if Turbo Boost should be disabled",
+          "   (load kernel extension), true if it should be enabled (unload",
+          "   kernel extension if loaded).",
+          " * notify - Optional boolean indicating whether a notification",
+          "   should be produced. If not given, the value of",
+          "   TurboBoost.notify is used.",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:setState(state)",
+        "type" : "Method",
+        "returns" : [
+          " * Boolean indicating new state"
+        ],
+        "def" : "TurboBoost:setState(state)",
+        "desc" : "Sets whether Turbo Boost should be disabled (kernel extension"
+      },
+      {
+        "name" : "status",
+        "stripped_doc" : [
+          "Check whether Turbo Boost is enabled",
+          ""
+        ],
+        "doc" : "Check whether Turbo Boost is enabled\n\nReturns:\n * true if TurboBoost is enabled (kernel ext not loaded), false otherwise.",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:status()",
+        "type" : "Method",
+        "returns" : [
+          " * true if TurboBoost is enabled (kernel ext not loaded), false otherwise."
+        ],
+        "def" : "TurboBoost:status()",
+        "desc" : "Check whether Turbo Boost is enabled"
+      },
+      {
+        "name" : "toggle",
+        "stripped_doc" : [
+          "Toggle TurboBoost status",
+          ""
+        ],
+        "doc" : "Toggle TurboBoost status\n\nReturns:\n * New TurboBoost status, after the toggle",
+        "parameters" : [
+
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:toggle()",
+        "type" : "Method",
+        "returns" : [
+          " * New TurboBoost status, after the toggle"
+        ],
+        "def" : "TurboBoost:toggle()",
+        "desc" : "Toggle TurboBoost status"
+      },
+      {
+        "name" : "bindHotkeys",
+        "stripped_doc" : [
+          "Binds hotkeys for TurboBoost",
+          ""
+        ],
+        "doc" : "Binds hotkeys for TurboBoost\n\nParameters:\n * mapping - A table containing hotkey objifier\/key details for the following items:\n  * hello - Say Hello",
+        "parameters" : [
+          " * mapping - A table containing hotkey objifier\/key details for the following items:",
+          "  * hello - Say Hello"
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "def" : "TurboBoost:bindHotkeys(mapping)",
+        "desc" : "Binds hotkeys for TurboBoost"
+      },
+      {
+        "name" : "start",
+        "stripped_doc" : [
+          "Starts TurboBoost",
+          ""
+        ],
+        "doc" : "Starts TurboBoost\n\nParameters:\n * None\n\nReturns:\n * The TurboBoost object",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:start()",
+        "type" : "Method",
+        "returns" : [
+          " * The TurboBoost object"
+        ],
+        "def" : "TurboBoost:start()",
+        "desc" : "Starts TurboBoost"
+      },
+      {
+        "name" : "stop",
+        "stripped_doc" : [
+          "Stops TurboBoost",
+          ""
+        ],
+        "doc" : "Stops TurboBoost\n\nParameters:\n * None\n\nReturns:\n * The TurboBoost object",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "notes" : [
+
+        ],
+        "signature" : "TurboBoost:stop()",
+        "type" : "Method",
+        "returns" : [
+          " * The TurboBoost object"
+        ],
+        "def" : "TurboBoost:stop()",
+        "desc" : "Stops TurboBoost"
+      }
+    ],
+    "name" : "TurboBoost"
+  }
+]

--- a/Source/TurboBoost.spoon/init.lua
+++ b/Source/TurboBoost.spoon/init.lua
@@ -1,0 +1,257 @@
+--- === TurboBoost ===
+---
+--- A spoon to load/unload the Turbo Boost Disable kernel extension
+--- from https://github.com/rugarciap/Turbo-Boost-Switcher.
+---
+--- Note: this spoon by default uses sudo to load/unload the kernel
+--- extension, so for it to work from Hammerspoon, you need to
+--- configure sudo to be able to load/unload the extension without a
+--- password, or configure the load_kext_cmd and unload_kext_cmd
+--- variables to use some other mechanism that prompts you for the
+--- credentials.
+---
+--- For example, the following configuration (stored in
+--- /etc/sudoers.d/turboboost) can be used to allow loading and
+--- unloading the module without a password:
+--- ```
+--- Cmnd_Alias    TURBO_OPS = /sbin/kextunload /Applications/Turbo Boost Switcher.app/Contents/Resources/DisableTurboBoost.64bits.kext, /usr/bin/kextutil /Applications/Turbo Boost Switcher.app/Contents/Resources/DisableTurboBoost.64bits.kext
+---
+--- %admin ALL=(ALL) NOPASSWD: TURBO_OPS
+--- ```
+---
+--- If you use this, please support the author of Turbo Boost Disabler
+--- by purchasing the Pro version of the app!
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TurboBoost.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/TurboBoost.spoon.zip)
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "TurboBoost"
+obj.version = "0.1"
+obj.author = "Diego Zamboni <diego@zzamboni.org>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- TurboBoost.logger
+--- Variable
+--- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.logger = hs.logger.new('TurboBoost')
+
+obj.menuBarItem = nil
+obj.wakeupWatcher = nil
+
+--- TurboBoost.disable_on_start
+--- Variable
+--- Boolean to indicate whether Turbo Boost should be disabled when the Spoon starts. Defaults to false.
+obj.disable_on_start = false
+
+--- TurboBoost.reenable_on_stop
+--- Variable
+--- Boolean to indicate whether Turbo Boost should be reenabled when the Spoon stops. Defaults to true.
+obj.reenable_on_stop = true
+
+--- TurboBoost.kext_path
+--- Variable
+--- Where the DisableTurboBoost.kext file is located.
+obj.kext_path = "/Applications/Turbo Boost Switcher.app/Contents/Resources/DisableTurboBoost.64bits.kext"
+
+--- TurboBoost.load_kext_cmd
+--- Variable
+--- Command to execute to load the DisableTurboBoost kernel
+--- extension. This command must execute with root privileges and
+--- either query the user for the credentials, or be configured
+--- (e.g. with sudo) to run without prompting. The string "%s" in this
+--- variable gets replaced with the value of
+--- TurboBoost.kext_path
+obj.load_kext_cmd = "/usr/bin/sudo /usr/bin/kextutil '%s'"
+
+--- TurboBoost.unload_kext_cmd
+--- Variable
+--- Command to execute to unload the DisableTurboBoost kernel
+--- extension. This command must execute with root privileges and
+--- either query the user for the credentials, or be configured
+--- (e.g. with sudo) to run without prompting. The string "%s" in this
+--- variable gets replaced with the value of
+--- TurboBoost.kext_path
+obj.unload_kext_cmd = "/usr/bin/sudo /sbin/kextunload '%s'"
+
+--- TurboBoost.check_kext_cmd
+--- Variable
+--- Command to execute to check whether the DisableTurboBoost kernel
+--- extension is loaded.
+obj.check_kext_cmd = "/usr/sbin/kextstat | grep com.rugarciap.DisableTurboBoost"
+
+--- TurboBoost.notify
+--- Variable
+--- Boolean indicating whether notifications should be generated when
+--- Turbo Boost is enabled/disabled.
+obj.notify = true
+
+--- TurboBoost.enabled_icon_path
+--- Variable
+--- Where to find the icon to use for the "Enabled" icon. Defaults to
+--- using the one from the Turbo Boost application.
+obj.enabled_icon_path = "/Applications/Turbo Boost Switcher.app/Contents/Resources/icon.tiff"
+
+--- TurboBoost.disabled_icon_path
+--- Variable
+--- Where to find the icon to use for the "Disabled" icon. Defaults to
+--- using the one from the Turbo Boost application.
+obj.disabled_icon_path = "/Applications/Turbo Boost Switcher.app/Contents/Resources/icon_off.tiff"
+
+--- TurboBoost:setState(state)
+--- Method
+--- Sets whether Turbo Boost should be disabled (kernel extension
+--- loaded) or enabled (normal state, kernel extension not loaded).
+---
+--- Parameters:
+---  * state - A boolean, false if Turbo Boost should be disabled
+---    (load kernel extension), true if it should be enabled (unload
+---    kernel extension if loaded).
+---  * notify - Optional boolean indicating whether a notification
+---    should be produced. If not given, the value of
+---    TurboBoost.notify is used.
+---
+--- Returns:
+---  * Boolean indicating new state
+function obj:setState(state, notify)
+  local curstatus = self:status()
+  if curstatus ~= state then
+    local cmd = string.format(obj.load_kext_cmd, obj.kext_path)
+    if state then
+      cmd = string.format(obj.unload_kext_cmd, obj.kext_path)
+    end
+    self.logger.df("Will execute command '%s'", cmd)
+    if notify == nil then
+      notify = obj.notify
+    end
+    out,st,ty,rc = hs.execute(cmd)
+    if not st then
+      self.logger.ef("Error executing '%s'. Output: %s", cmd, out)
+    else
+      self:setDisplay(state)
+      if notify then
+        hs.notify.new({
+            title = "Turbo Boost " .. (state and "enabled" or "disabled"),
+            subTitle = "",
+            informativeText = "",
+            setIdImage = hs.image.imageFromPath(self.iconPathForState(state))
+        }):send()
+      end
+    end
+  end
+  return self:status()
+end
+
+--- TurboBoost:status()
+--- Method
+--- Check whether Turbo Boost is enabled
+---
+--- Returns:
+---  * true if TurboBoost is enabled (kernel ext not loaded), false otherwise.
+function obj:status()
+  local cmd = obj.check_kext_cmd
+  out,st,ty,rc = hs.execute(cmd)
+  return (not st)
+end
+
+--- TurboBoost:toggle()
+--- Method
+--- Toggle TurboBoost status
+---
+--- Returns:
+---  * New TurboBoost status, after the toggle
+function obj:toggle()
+  self:setState(not self:status())
+  return self:status()
+end
+
+--- TurboBoost:bindHotkeys(mapping)
+--- Method
+--- Binds hotkeys for TurboBoost
+---
+--- Parameters:
+---  * mapping - A table containing hotkey objifier/key details for the following items:
+---   * hello - Say Hello
+function obj:bindHotkeys(mapping)
+  local spec = { toggle = hs.fnutils.partial(self.toggle, self) }
+  hs.spoons.bindHotkeysToSpec(spec, mapping)
+end
+
+--- TurboBoost:start()
+--- Method
+--- Starts TurboBoost
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The TurboBoost object
+function obj:start()
+    if self.menuBarItem or self.wakeupWatcher then self:stop() end
+    self.menuBarItem = hs.menubar.new()
+    self.menuBarItem:setClickCallback(self.clicked)
+    self:setDisplay(self:status())
+    self.wakeupWatcher = hs.caffeinate.watcher.new(self.wokeUp):start()
+    if self.disable_on_start then
+      self:setState(false)
+    end
+    return self
+end
+
+--- TurboBoost:stop()
+--- Method
+--- Stops TurboBoost
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * The TurboBoost object
+function obj:stop()
+  if self.reenable_on_stop then
+    self:setState(true)
+  end
+  if self.menuBarItem then self.menuBarItem:delete() end
+  self.menuBarItem = nil
+  if self.wakeupWatcher then self.wakeupWatcher:stop() end
+  self.wakeupWatcher = nil
+
+  return self
+end
+
+function obj.iconPathForState(state)
+  if state then
+    return obj.enabled_icon_path
+  else
+    return obj.disabled_icon_path
+  end
+end
+
+function obj:setDisplay(state)
+  obj.menuBarItem:setIcon(obj.iconPathForState(state))
+end
+
+function obj.clicked()
+  obj:setDisplay(obj:toggle())
+end
+
+-- This function is called when the machine wakes up and, if the
+-- module was loaded, it unloads/reloads it to disable Turbo Boost
+-- again
+function obj.wokeUp(event)
+  obj.logger.df("In obj.wokeUp, event = %d\n", event)
+  if event == hs.caffeinate.watcher.systemDidWake then
+    obj.logger.d("  Received systemDidWake event!\n")
+    if not obj:status() then
+      obj.logger.d("  Toggling TurboBoost on and back off\n")
+      obj:toggle()
+      hs.timer.usleep(20000)
+      obj:toggle()
+    end
+  end
+end
+
+return obj


### PR DESCRIPTION
A spoon to load/unload the Turbo Boost Disable kernel extension from https://github.com/rugarciap/Turbo-Boost-Switcher.

The Turbo Boost status can be controlled from a menubar item and optionally using a hotkey.

Note: this spoon by default uses sudo to load/unload the kernel extension, so for it to work from Hammerspoon, you need to configure sudo to be able to load/unload the extension without a password, or configure the load_kext_cmd and unload_kext_cmd variables to use some other mechanism that prompts you for the credentials.

For example, the following configuration (stored in `/etc/sudoers.d/turboboost`) can be used to allow loading and unloading the module without a password:

```
Cmnd_Alias    TURBO_OPS = /sbin/kextunload /Applications/Turbo Boost Switcher.app/Contents/Resources/DisableTurboBoost.64bits.kext, /usr/bin/kextutil /Applications/Turbo Boost Switcher.app/Contents/Resources/DisableTurboBoost.64bits.kext

%admin ALL=(ALL) NOPASSWD: TURBO_OPS
```