### PR TITLE
New configuration parameter URLDispatcher.url_redir_decoders

### DIFF
--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -36,7 +36,7 @@ obj.decode_slack_redir_urls = true
 --- dispatching them. Each list element must be a list itself with four
 --- elements:
 ---   * a name to identify the decoder
----   * a regex to match against the URL
+---   * a [Lua pattern](https://www.lua.org/pil/20.2.html) to match against the URL
 ---   * a replacement pattern to apply if a match is found.
 ---   * (optional) whether to skip URL-decoding of the resulting string (by default the results are always decoded)
 --- The first two values are passed as arguments to

--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -13,7 +13,7 @@ obj.__index = obj
 
 -- Metadata
 obj.name = "URLDispatcher"
-obj.version = "0.1"
+obj.version = "0.2"
 obj.author = "Diego Zamboni <diego@zzamboni.org>"
 obj.homepage = "https://github.com/Hammerspoon/Spoons"
 obj.license = "MIT - https://opensource.org/licenses/MIT"


### PR DESCRIPTION
List containing optional additional redirection decoders (other than the known Slack decoder, which is enabled by `URLDispatcher.decode_slack_redir_urls` to apply to URLs before dispatching them. Each list element must be a list itself with four elements:
  * a name to identify the decoder
  * a regex to match against the URL
  * a replacement pattern to apply if a match is found.
  * (optional) whether to skip URL-decoding of the resulting
    string (by default the results are always decoded)