### PR TITLE
HSearch btabs: use tab switch instead of reload/new

### DIFF
--- a/Source/HSearch.spoon/hs_btabs.lua
+++ b/Source/HSearch.spoon/hs_btabs.lua
@@ -26,7 +26,7 @@ local function browserTabsRequest()
         -- Notice `output` key and its `arg`. The built-in output contains `browser`, `safari`, `chrome`, `firefon`, `clipboard`, `keystrokes`. You can define new output type if you like.
         if stat then
             chooser_data = hs.fnutils.imap(data, function(item)
-                return {text=item[1], subText=item[2], image=hs.image.imageFromPath(obj.spoonPath .. "/resources/safari.png"), output="safari", arg=item[2]}
+                return {text=item[1], subText=item[2], image=hs.image.imageFromPath(obj.spoonPath .. "/resources/safari.png"), output="safarifocus", arg=item[2]}
             end)
         end
     end
@@ -36,7 +36,7 @@ local function browserTabsRequest()
         if stat then
             for idx,val in pairs(data) do
                 -- Usually we want to open chrome tabs in Google Chrome.
-                table.insert(chooser_data, {text=val[1], subText=val[2], image=hs.image.imageFromPath(obj.spoonPath .. "/resources/chrome.png"), output="chrome", arg=val[2]})
+                table.insert(chooser_data, {text=val[1], subText=val[2], image=hs.image.imageFromPath(obj.spoonPath .. "/resources/chrome.png"), output="chromefocus", arg=val[2]})
             end
         end
     end

--- a/Source/HSearch.spoon/init.lua
+++ b/Source/HSearch.spoon/init.lua
@@ -44,6 +44,22 @@ function obj:restoreOutput()
     local function openWithFirefox(arg)
         hs.urlevent.openURLWithBundle(arg, "org.mozilla.firefox")
     end
+    local function focusTabInBrowser(browser, arg) 
+        hs.osascript.javascript([[
+            (function() {
+                var chrome = Application(']] .. browser .. [[');
+                chrome.activate();
+                for (win of chrome.windows()) {
+                  var tabIndex =
+                    win.tabs().findIndex(tab => tab.url() == "]] .. arg .. [[");
+                  if (tabIndex != -1) {
+                    win.activeTabIndex = (tabIndex + 1);
+                    win.index = 1;
+                  }
+                }
+            })();
+        ]])
+    end
     local function copyToClipboard(arg)
         hs.pasteboard.setContents(arg)
     end
@@ -58,6 +74,8 @@ function obj:restoreOutput()
     obj.output_pool["firefox"] = openWithFirefox
     obj.output_pool["clipboard"] = copyToClipboard
     obj.output_pool["keystrokes"] = sendKeyStrokes
+    obj.output_pool["chromefocus"] = hs.fnutils.partial(focusTabInBrowser, 'Google Chrome')
+    obj.output_pool["safarifocus"] = hs.fnutils.partial(focusTabInBrowser, 'Safari')
 end
 
 function obj:init()


### PR DESCRIPTION
Currently the behavior for (HSearch) browser tabs are:
- (Safari) switch to that tab and reload, or
- (Chrome) open a new tab with the URL.

Changing both to just focusing on the tab in browser. Using javascript to find corresponding tabs with the URL.