### PR TITLE
Arrange Desktop Spoon

### DIFF
--- a/Source/ArrangeDesktop.spoon/docs.json
+++ b/Source/ArrangeDesktop.spoon/docs.json
@@ -1,0 +1,246 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "def" : "ArrangeDesktop.logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logger",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Contains the configured desktop arrangements",
+        "def" : "ArrangeDesktop.arrangements",
+        "stripped_doc" : [
+          "Contains the configured desktop arrangements"
+        ],
+        "desc" : "Contains the configured desktop arrangements",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop.arrangements",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "arrangements",
+        "parameters" : [
+
+        ]
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "desc" : "Utilities for arranging your desktop how you like it.",
+    "Constructor" : [
+
+    ],
+    "doc" : "Utilities for arranging your desktop how you like it.\n\nPositioning logic adapted from https:\/\/github.com\/dploeger\/hammerspoon-window-manager",
+    "Method" : [
+      {
+        "doc" : "Arrange the desktop based on a given configuration\n\nParameters:\n* arrangement - table of arrangement data",
+        "def" : "ArrangeDesktop:arrange",
+        "stripped_doc" : [
+          "Arrange the desktop based on a given configuration",
+          ""
+        ],
+        "desc" : "Arrange the desktop based on a given configuration",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:arrange",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "arrange",
+        "parameters" : [
+          "* arrangement - table of arrangement data"
+        ]
+      },
+      {
+        "doc" : "Add menu items to a table for each configured desktop arrangment.\n\nParameters:\n* menuItems - table of menu items\n* arrangements - table of desktop arrangements\n\nReturns:\ntable of menu items",
+        "def" : "ArrangeDesktop:addMenuItems",
+        "stripped_doc" : [
+          "Add menu items to a table for each configured desktop arrangment.",
+          ""
+        ],
+        "desc" : "Add menu items to a table for each configured desktop arrangment.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:addMenuItems",
+        "type" : "Method",
+        "returns" : [
+          "table of menu items"
+        ],
+        "name" : "addMenuItems",
+        "parameters" : [
+          "* menuItems - table of menu items",
+          "* arrangements - table of desktop arrangements",
+          ""
+        ]
+      },
+      {
+        "doc" : "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console.",
+        "def" : "ArrangeDesktop:logCurrentArrangement()",
+        "stripped_doc" : [
+          "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console."
+        ],
+        "desc" : "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:logCurrentArrangement()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "logCurrentArrangement",
+        "parameters" : [
+
+        ]
+      }
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Contains the configured desktop arrangements",
+        "def" : "ArrangeDesktop.arrangements",
+        "stripped_doc" : [
+          "Contains the configured desktop arrangements"
+        ],
+        "desc" : "Contains the configured desktop arrangements",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop.arrangements",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "arrangements",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "def" : "ArrangeDesktop.logger",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon."
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logger",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Add menu items to a table for each configured desktop arrangment.\n\nParameters:\n* menuItems - table of menu items\n* arrangements - table of desktop arrangements\n\nReturns:\ntable of menu items",
+        "def" : "ArrangeDesktop:addMenuItems",
+        "stripped_doc" : [
+          "Add menu items to a table for each configured desktop arrangment.",
+          ""
+        ],
+        "desc" : "Add menu items to a table for each configured desktop arrangment.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:addMenuItems",
+        "type" : "Method",
+        "returns" : [
+          "table of menu items"
+        ],
+        "name" : "addMenuItems",
+        "parameters" : [
+          "* menuItems - table of menu items",
+          "* arrangements - table of desktop arrangements",
+          ""
+        ]
+      },
+      {
+        "doc" : "Arrange the desktop based on a given configuration\n\nParameters:\n* arrangement - table of arrangement data",
+        "def" : "ArrangeDesktop:arrange",
+        "stripped_doc" : [
+          "Arrange the desktop based on a given configuration",
+          ""
+        ],
+        "desc" : "Arrange the desktop based on a given configuration",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:arrange",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "arrange",
+        "parameters" : [
+          "* arrangement - table of arrangement data"
+        ]
+      },
+      {
+        "doc" : "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console.",
+        "def" : "ArrangeDesktop:logCurrentArrangement()",
+        "stripped_doc" : [
+          "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console."
+        ],
+        "desc" : "Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console.",
+        "notes" : [
+
+        ],
+        "signature" : "ArrangeDesktop:logCurrentArrangement()",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "logCurrentArrangement",
+        "parameters" : [
+
+        ]
+      }
+    ],
+    "Field" : [
+
+    ],
+    "name" : "ArrangeDesktop"
+  }
+]

--- a/Source/ArrangeDesktop.spoon/init.lua
+++ b/Source/ArrangeDesktop.spoon/init.lua
@@ -1,0 +1,129 @@
+--- === ArrangeDesktop ===
+---
+--- Utilities for arranging your desktop how you like it.
+---
+--- Positioning logic adapted from https://github.com/dploeger/hammerspoon-window-manager
+
+local obj = {}
+obj.__index = obj
+
+-- Metadata
+obj.name = "ArrangeDesktop"
+obj.version = "1.0.0"
+obj.author = "Luis Cruz <sprak3000+github@gmail.com>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- ArrangeDesktop.logger
+--- Variable
+--- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.logger = hs.logger.new('ArrangeDesktop')
+
+--- ArrangeDesktop.arrangements
+--- Variable
+--- Contains the configured desktop arrangements
+obj.arrangements = {}
+
+-- Internal method - Positions all windows for an application based on the given criteria.
+--
+-- Parameters
+-- * app - table of the application instance
+-- * appTitle - the name of the application, e.g., Slack, Firefox, etc.
+-- * screen - table of the position of the screen (x, y integer pair) to place the application window into
+-- * frame - table of the frame details for the application window, e.g., {w=12, h=12, x=12, y=12}
+function obj:_positionApp(app, appTitle, screen, frame)
+    obj.logger.d('Positioning ' .. appTitle)
+
+    app:activate()
+    local windows = hs.window.filter.new(appTitle):getWindows()
+
+    for k, v in pairs(windows) do
+        obj.logger.d('Positioning window ' .. v:id() .. ' of app ' .. appTitle)
+        v:moveToScreen(screen)
+        v:setFrame(frame, 0)
+    end
+end
+
+--- ArrangeDesktop:arrange
+--- Method
+--- Arrange the desktop based on a given configuration
+---
+--- Parameters:
+--- * arrangement - table of arrangement data
+function obj:arrange(arrangement)
+    for monitorUUID, monitorDetails in pairs(obj.arrangements[arrangement]) do
+        if hs.screen.find(monitorUUID) ~= nil then
+            for appName, position in pairs(monitorDetails['apps']) do
+                app = hs.application.get(appName)
+                if app ~= nil then
+                    obj:_positionApp(app, appName, monitorUUID, position)
+                end
+            end
+        end
+    end
+end
+
+--- ArrangeDesktop:addMenuItems
+--- Method
+--- Add menu items to a table for each configured desktop arrangment.
+---
+--- Parameters:
+--- * menuItems - table of menu items
+--- * arrangements - table of desktop arrangements
+---
+--- Returns:
+--- table of menu items
+function obj:addMenuItems(menuItems, arrangements)
+    if menuItems == nil then
+        menuItems = {}
+    end
+
+    table.insert(menuItems, { title = "Log Current Desktop Arrangement", fn = function() obj:logCurrentArrangement() end })
+
+    if obj.arrangements ~= nil then
+        for k, v in pairs(obj.arrangements) do
+            table.insert(menuItems, { title = "Use " .. k .. " desktop arrangement", fn = function() obj:arrange(k) end })
+        end
+    end
+
+    return menuItems
+end
+
+--- ArrangeDesktop:logCurrentArrangement()
+--- Method
+--- Build up the configuration for the current desktop arrangement and log it to the Hammerspoon console.
+function obj:logCurrentArrangement()
+    local frameTemplate = '{ w = wVal, h = hVal, x = xVal, y = yVal }'
+    local cmdTemplate = '    positionApp(\'appName\', monitorUUID, frame)'
+    local output = { "\n['<ARRANGEMENT NAME>'] = {" }
+
+    for k, v in pairs(hs.screen.allScreens()) do
+        table.insert(output, "    ['" .. v:getUUID() .. "'] = {")
+        table.insert(output, "        ['Montior Name'] = '" .. v:name() .. "',")
+        table.insert(output, "        ['apps'] = {")
+
+        local windows = hs.window.filter.new(true):setScreens(v:getUUID()):getWindows()
+        for wi, wv in pairs(windows) do
+            local frame = frameTemplate
+
+            wv:focus()
+            for i, t in pairs(wv:frame()) do
+                local pattern = string.gsub(i, '_', '') .. 'Val'
+                frame = string.gsub(frame, pattern, t)
+            end
+
+            table.insert(output, "            ['" .. wv:application():title() .. "'] = " .. frame .. "")
+        end
+
+        table.insert(output, "        },")
+        table.insert(output, "    },")
+    end
+
+    table.insert(output, '}')
+
+    obj.logger.i('--------------------------------------------------------------------------------')
+    obj.logger.i(table.concat(output, "\n"))
+    obj.logger.i('--------------------------------------------------------------------------------')
+end
+
+return obj


### PR DESCRIPTION
This spoon arranges the windows on your desktop based on supplied configurations. The `Log Current Desktop Arrangement` menu item builds out the configuration for you and places it in the Hammerspoon console. Once you have one or more configurations, menu items will place the windows appropriately.