### PR TITLE
Add new spoon for launching apps with hotkeys.

### DIFF
--- a/Source/AppLauncher.spoon/docs.json
+++ b/Source/AppLauncher.spoon/docs.json
@@ -1,0 +1,124 @@
+[
+  {
+    "Constant" : [
+
+    ],
+    "submodules" : [
+
+    ],
+    "Function" : [
+
+    ],
+    "Variable" : [
+      {
+        "doc" : "Modifier keys used when launching apps\n\nDefault value: `{\"ctrl\", \"alt\"}`",
+        "desc" : "Modifier keys used when launching apps",
+        "stripped_doc" : [
+          "Modifier keys used when launching apps",
+          "",
+          "Default value: `{\"ctrl\", \"alt\"}`"
+        ],
+        "def" : "AppLauncher.modifiers",
+        "notes" : [
+
+        ],
+        "signature" : "AppLauncher.modifiers",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "modifiers",
+        "parameters" : [
+
+        ]
+      }
+    ],
+    "stripped_doc" : [
+
+    ],
+    "desc" : "Simple spoon for launching apps with single letter hotkeys.",
+    "Deprecated" : [
+
+    ],
+    "type" : "Module",
+    "Constructor" : [
+
+    ],
+    "doc" : "Simple spoon for launching apps with single letter hotkeys.\n\nExample configuration using SpoonInstall.spoon:\n```\nspoon.SpoonInstall:andUse(\"AppLauncher\", {\n  hotkeys = {\n    c = \"Calendar\",\n    d = \"Discord\",\n    f = \"Firefox Developer Edition\",\n    n = \"Notes\",\n    p = \"1Password 7\",\n    r = \"Reeder\",\n    t = \"Kitty\",\n    z = \"Zoom.us\",\n  }\n})\n```\n\nDownload: [https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/AppLauncher.spoon.zip](https:\/\/github.com\/Hammerspoon\/Spoons\/raw\/master\/Spoons\/AppLauncher.spoon.zip)",
+    "Method" : [
+      {
+        "doc" : "Binds hotkeys for AppLauncher\n\nParameters:\n * mapping - A table containing single characters with their associated app",
+        "desc" : "Binds hotkeys for AppLauncher",
+        "stripped_doc" : [
+          "Binds hotkeys for AppLauncher",
+          ""
+        ],
+        "def" : "AppLauncher:bindHotkeys(mapping)",
+        "notes" : [
+
+        ],
+        "signature" : "AppLauncher:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing single characters with their associated app"
+        ]
+      }
+    ],
+    "Command" : [
+
+    ],
+    "items" : [
+      {
+        "doc" : "Modifier keys used when launching apps\n\nDefault value: `{\"ctrl\", \"alt\"}`",
+        "desc" : "Modifier keys used when launching apps",
+        "stripped_doc" : [
+          "Modifier keys used when launching apps",
+          "",
+          "Default value: `{\"ctrl\", \"alt\"}`"
+        ],
+        "def" : "AppLauncher.modifiers",
+        "notes" : [
+
+        ],
+        "signature" : "AppLauncher.modifiers",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "modifiers",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "doc" : "Binds hotkeys for AppLauncher\n\nParameters:\n * mapping - A table containing single characters with their associated app",
+        "desc" : "Binds hotkeys for AppLauncher",
+        "stripped_doc" : [
+          "Binds hotkeys for AppLauncher",
+          ""
+        ],
+        "def" : "AppLauncher:bindHotkeys(mapping)",
+        "notes" : [
+
+        ],
+        "signature" : "AppLauncher:bindHotkeys(mapping)",
+        "type" : "Method",
+        "returns" : [
+
+        ],
+        "name" : "bindHotkeys",
+        "parameters" : [
+          " * mapping - A table containing single characters with their associated app"
+        ]
+      }
+    ],
+    "Field" : [
+
+    ],
+    "name" : "AppLauncher"
+  }
+]

--- a/Source/AppLauncher.spoon/init.lua
+++ b/Source/AppLauncher.spoon/init.lua
@@ -1,0 +1,54 @@
+--- === AppLauncher ===
+---
+--- Simple spoon for launching apps with single letter hotkeys.
+---
+--- Example configuration using SpoonInstall.spoon:
+--- ```
+--- spoon.SpoonInstall:andUse("AppLauncher", {
+---   hotkeys = {
+---     c = "Calendar",
+---     d = "Discord",
+---     f = "Firefox Developer Edition",
+---     n = "Notes",
+---     p = "1Password 7",
+---     r = "Reeder",
+---     t = "Kitty",
+---     z = "Zoom.us",
+---   }
+--- })
+--- ```
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/AppLauncher.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/AppLauncher.spoon.zip)
+
+local obj = {}
+obj.__index = obj
+
+-- Metadata
+obj.name = "AppLauncher"
+obj.version = "1.0.0"
+obj.author = "Mathias Jean Johansen <mathias@mjj.io>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "ISC - https://opensource.org/licenses/ISC"
+
+--- AppLauncher.modifiers
+--- Variable
+--- Modifier keys used when launching apps
+---
+--- Default value: `{"ctrl", "alt"}`
+obj.modifiers = {"ctrl", "alt"}
+
+--- AppLauncher:bindHotkeys(mapping)
+--- Method
+--- Binds hotkeys for AppLauncher
+---
+--- Parameters:
+---  * mapping - A table containing single characters with their associated app
+function obj:bindHotkeys(mapping)
+  for key, app in pairs(mapping) do
+    hs.hotkey.bind(obj.modifiers, key, function()
+      hs.application.launchOrFocus(app)
+    end)
+  end
+end
+
+return obj


### PR DESCRIPTION
This pull request adds a new spoon that allows you to launch/focus apps using the modifier key and just a single letter. An example configuration could like this:

```lua
spoon.SpoonInstall:andUse("AppLauncher", {
  hotkeys = {
    c = "Calendar",
    d = "Discord",
    f = "Firefox Developer Edition",
    n = "Notes",
    p = "1Password 7",
    r = "Reeder",
    t = "Kitty",
    z = "Zoom.us",
  }
})
```

With this configuration, hitting <kbd>hyper</kbd><kbd>c</kbd> would launch Calendar.app, <kbd>hyper</kbd><kbd>d</kbd> would launch Discord and so forth.

I hope people will find it useful.