### PR TITLE
WinWin: Use hs.screen:frame() instead of hs.screen:fullFrame()

### DIFF
--- a/Source/WinWin.spoon/init.lua
+++ b/Source/WinWin.spoon/init.lua
@@ -32,7 +32,7 @@ function obj:stepMove(direction)
     local cwin = hs.window.focusedWindow()
     if cwin then
         local cscreen = cwin:screen()
-        local cres = cscreen:fullFrame()
+        local cres = cscreen:frame()
         local stepw = cres.w/obj.gridparts
         local steph = cres.h/obj.gridparts
         local wtopleft = cwin:topLeft()
@@ -62,7 +62,7 @@ function obj:stepResize(direction)
     local cwin = hs.window.focusedWindow()
     if cwin then
         local cscreen = cwin:screen()
-        local cres = cscreen:fullFrame()
+        local cres = cscreen:frame()
         local stepw = cres.w/obj.gridparts
         local steph = cres.h/obj.gridparts
         local wsize = cwin:size()
@@ -103,7 +103,7 @@ function obj:moveAndResize(option)
     local cwin = hs.window.focusedWindow()
     if cwin then
         local cscreen = cwin:screen()
-        local cres = cscreen:fullFrame()
+        local cres = cscreen:frame()
         local stepw = cres.w/obj.gridparts
         local steph = cres.h/obj.gridparts
         local wf = cwin:frame()
@@ -193,7 +193,7 @@ function obj:centerCursor()
     local cwin = hs.window.focusedWindow()
     local wf = cwin:frame()
     local cscreen = cwin:screen()
-    local cres = cscreen:fullFrame()
+    local cres = cscreen:frame()
     if cwin then
         -- Center the cursor one the focused window
         hs.mouse.setAbsolutePosition({x=wf.x+wf.w/2, y=wf.y+wf.h/2})


### PR DESCRIPTION
The `hs.screen:fullFrame()` function returns the screen frame _including_ the dock and the menu, whose space cannot be occupied by windows. The end result is that when you use WinWin to put window A to `cornerNE` and window B to `cornerSE`, the lower border of A and the upper border of B overlap with each other.

This PR replaces the `hs.screen:fullFrame()` calls in WinWin with `hs.screen:frame()` to fix this issue.