### PR TITLE
MouseFollowsFocus: fix for dragging non-focused window

### DIFF
--- a/Source/MouseFollowsFocus.spoon/init.lua
+++ b/Source/MouseFollowsFocus.spoon/init.lua
@@ -58,10 +58,13 @@ end
 
 --- MouseFollowsFocus:updateMouse(window)
 --- Method
---- Sets the mouse position to the center of the given window
+--- Moves the mouse to the center of the given window unless it's already inside the window
 function obj:updateMouse(window)
-  local pos = window:frame().center
-  hs.mouse.setAbsolutePosition(pos)
+  local current_pos = hs.geometry(hs.mouse.getAbsolutePosition())
+  local frame = window:frame()
+  if not current_pos:inside(frame) then
+    hs.mouse.setAbsolutePosition(frame.center)
+  end
 end
 
 return obj


### PR DESCRIPTION
Prior to this, dragging a non-focused window made it jump to the original
center of the window.