### PR TITLE
Seal Spoon : Avoid search by space (" ")

### DIFF
--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -286,7 +286,7 @@ function obj.choicesCallback()
     query = obj.chooser:query()
     cmd = nil
     query_words = {}
-    if query == "" then
+    if tostring(query):find("^%s*$") ~= nil then
         return choices
     end
     for word in string.gmatch(query, "%S+") do


### PR DESCRIPTION
### When searching by space (meaning " ") an error is thrown:
```
ERROR: LuaSkin: hs.chooser:choices error - .hammerspoon/Spoons/Seal.spoon/init.lua:303: attempt to index a nil value (global 'cmd')
stack traceback:
  .hammerspoon/Spoons/Seal.spoon/init.lua:303: in function 'Seal.choicesCallback'
  [C]: in method 'refreshChoicesCallback'
  .hammerspoon/Spoons/Seal.spoon/init.lua:344: in function <.hammerspoon/Spoons/Seal.spoon/init.lua:344>
```