### PR TITLE
Seal: bigger size for favicon

### DIFF
--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -176,7 +176,7 @@ function obj.bareActions(query)
 end
 
 function obj.favIcon(url)
-   local query=string.format("http://www.google.com/s2/favicons?domain_url=%s", hs.http.encodeForQuery(url))
+   local query=string.format("http://www.google.com/s2/favicons?sz=64&domain_url=%s", hs.http.encodeForQuery(url))
    return hs.image.imageFromURL(query)
 end
 


### PR DESCRIPTION
The api provides a parameter (`sz`) to specify the size of the favicon.

I pushed with value 64, fell free to change it.

Difference:
<img width="633" alt="before" src="https://user-images.githubusercontent.com/1574795/113773865-d56a5880-9726-11eb-85ba-62e7a95b54fb.png">

<img width="635" alt="after" src="https://user-images.githubusercontent.com/1574795/113773857-d4392b80-9726-11eb-9bb5-7d50b600db8f.png">



Unfortunately I could not find any documentation for this api.