### PR TITLE
Seal useractions query encode

### DIFF
--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -270,7 +270,8 @@ function obj.completionCallback(row)
       if obj.actions[row.actionname].fn then
          obj.actions[row.actionname].fn(row.arg)
       elseif obj.actions[row.actionname].url then
-         local url = string.gsub(obj.actions[row.actionname].url, '${query}', row.arg)
+         row.arg = hs.http.encodeForQuery(row.arg)
+         local url = string.gsub(obj.actions[row.actionname].url, '${query}', row.arg:gsub("%%", "%%%%"))
          obj.openURL(url)
       end
    end


### PR DESCRIPTION
When typing more than one word when using a `useraction` with `keyword`, both click to choose or pressing ENTER to choose will not open the URL.

Using the `Translate using Leo` as example, typing `leo one` it will work fine and open  the url with the `...?search=one`, but when typing `leo one two` nothing happens.

This will encode the value and escape the `%`.