### PR TITLE
WindowSigils: stop relying on a global variable

### DIFF
--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -270,7 +270,7 @@ function obj:refresh()
     end
 
     local new_elements = {}
-    local windows = sigils:orderedWindows()
+    local windows = self:orderedWindows()
     for i, window in ipairs(windows) do
       local wframe = window:frame()
       table.insert(new_elements, {


### PR DESCRIPTION
The caller may not use `sigils` as the name of the global variable (or set a global variable at all).