### PR TITLE
WindowSigils: Fixes and support for stacking windows and empty spaces

### DIFF
--- a/Source/WindowSigils.spoon/coordinate_set.lua
+++ b/Source/WindowSigils.spoon/coordinate_set.lua
@@ -1,0 +1,60 @@
+--
+-- An ordered set of ordered coordinates, e.g. xs or ys.  Coordinates
+-- should be added, then 'sort' called before 'offset' is called to find
+-- a coordinate's index.
+--
+
+local CoordinateSet = {}
+
+function CoordinateSet:new()
+  local o = {
+    coordinates = {},
+    xref = {},
+  }
+  setmetatable(o, self)
+  return o
+end
+
+function CoordinateSet:add(coordinate)
+  if not self.xref[coordinate] then
+    self.xref[coordinate] = true
+    table.insert(self.coordinates, coordinate)
+  end
+end
+
+function CoordinateSet:sort()
+  table.sort(self.coordinates)
+end
+
+function CoordinateSet:__index(i)
+  if type(i) == "number" then
+    return self.coordinates[i]
+  end
+  return CoordinateSet[i]
+end
+
+function CoordinateSet:__len()
+  return #self.coordinates
+end
+
+function CoordinateSet:offset(value)
+  if not self.xref[value] then
+    return nil
+  end
+  local lo = 1
+  local hi = #self.coordinates
+  local mid
+  while lo <= hi do
+    mid = hs.math.floor((lo + hi) / 2)
+    if self.coordinates[mid] == value then
+      return mid
+    elseif self.coordinates[mid] < value then
+      lo = mid + 1
+    else
+      hi = mid - 1
+    end
+  end
+  return mid
+end
+
+return CoordinateSet

--- a/Source/WindowSigils.spoon/coordinate_set.lua
+++ b/Source/WindowSigils.spoon/coordinate_set.lua
@@ -24,6 +24,9 @@ end
 
 function CoordinateSet:sort()
   table.sort(self.coordinates)
+  for i, value in ipairs(self.coordinates) do
+      self.xref[value] = i
+  end
 end
 
 function CoordinateSet:__index(i)
@@ -38,23 +41,7 @@ function CoordinateSet:__len()
 end
 
 function CoordinateSet:offset(value)
-  if not self.xref[value] then
-    return nil
-  end
-  local lo = 1
-  local hi = #self.coordinates
-  local mid
-  while lo <= hi do
-    mid = hs.math.floor((lo + hi) / 2)
-    if self.coordinates[mid] == value then
-      return mid
-    elseif self.coordinates[mid] < value then
-      lo = mid + 1
-    else
-      hi = mid - 1
-    end
-  end
-  return mid
+  return self.xref[value]
 end
 
 return CoordinateSet

--- a/Source/WindowSigils.spoon/empty_window.lua
+++ b/Source/WindowSigils.spoon/empty_window.lua
@@ -1,0 +1,27 @@
+local EmptyWindow = {}
+EmptyWindow.__index = EmptyWindow
+
+function EmptyWindow:new(frame)
+  local obj = {
+    _frame = frame
+  }
+  setmetatable(obj, self)
+  return obj
+end
+
+function EmptyWindow:id()
+  return -1
+end
+
+function EmptyWindow:isVisible()
+  return true
+end
+
+function EmptyWindow:frame()
+  return self._frame
+end
+
+function EmptyWindow:setFrame(frame, speed)
+end
+
+return EmptyWindow

--- a/Source/WindowSigils.spoon/empty_window.lua
+++ b/Source/WindowSigils.spoon/empty_window.lua
@@ -24,4 +24,12 @@ end
 function EmptyWindow:setFrame(frame, speed)
 end
 
+function EmptyWindow:application()
+  return nil
+end
+
+function EmptyWindow:title()
+  return "<empty>"
+end
+
 return EmptyWindow

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -220,7 +220,11 @@ function obj:orderedWindows()
     local af, bf = a:frame(), b:frame()
     if af.x < bf.x then return true end
     if af.x > bf.x then return false end
-    return af.y < bf.y
+    if af.y < bf.y then return true end
+    if af.y > bf.y then return false end
+    -- In order to keep the sort somewhat stable, use window ids
+    local aid, bid = a:id(), b:id()
+    return aid < bid
   end)
   return windows
 end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -249,18 +249,11 @@ function obj:_addEmptySpaceWindows(windows)
   -- Make a grid with all window boundaries
   local space_map = SpaceMap:new()
 
-  function add_frame(frame)
-    space_map.xs:add(frame.x1)
-    space_map.xs:add(frame.x2 + 1)
-    space_map.ys:add(frame.y1)
-    space_map.ys:add(frame.y2 + 1)
-  end
-
   for _, screen in ipairs(hs.screen.allScreens()) do
-    add_frame(screen:frame())
+    space_map:add_frame(screen:frame())
   end
   for _, window in ipairs(windows) do
-    add_frame(window:frame())
+    space_map:add_frame(window:frame())
   end
 
   space_map.xs:sort()

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -258,6 +258,20 @@ function obj:_addEmptySpaceWindows(windows)
   end
 end
 
+function obj:_removeUnuseableWindows(windows)
+  return hs.fnutils.filter(windows, function(window)
+    local app = window:application()
+    local bundleID
+    if app ~= nil then
+      bundleID = app:bundleID()
+    end
+    -- On Big Sur :(
+    if bundleID == "com.apple.notificationcenterui" then return false end
+    if bundleID == "com.apple.UserNotificationCenter" then return false end
+    return true
+  end)
+end
+
 --- WindowSigils:orderedWindows()
 --- Method
 --- A list of windows, in the order sigils are assigned.
@@ -266,6 +280,7 @@ end
 ---  * None
 function obj:orderedWindows()
   local windows = self.window_filter:getWindows()
+  windows = self:_removeUnuseableWindows(windows)
   self:_addEmptySpaceWindows(windows)
   table.sort(windows, function(a, b)
     local af, bf = a:frame(), b:frame()

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -251,48 +251,13 @@ function obj:_addEmptySpaceWindows(windows)
 
   -- find largest empty rectangles, prefer extending down
   for _, screen in ipairs(hs.screen.allScreens()) do
-    local screen_frame = screen:frame()
-    local i_start = space_map.ys:offset(screen_frame.y)
-    local j_start = space_map.xs:offset(screen_frame.x)
-    local i_end = space_map.ys:offset(screen_frame.y2 + 1) - 1
-    local j_end = space_map.xs:offset(screen_frame.x2 + 1) - 1
-
-    for top = i_start, i_end do
-      for left = j_start, j_end do
-        if not space_map.occupied[top][left] then
-
-          local bottom = top
-          while bottom + 1 <= i_end and not space_map.occupied[bottom + 1][left] do
-            bottom = bottom + 1
-          end
-
-          local right = nil
-          for i = top, bottom do
-            local row_right = left
-            while row_right + 1 <= j_end and not space_map.occupied[i][row_right + 1] do
-              row_right = row_right + 1
-            end
-            if right == nil or row_right < right then
-              right = row_right
-            end
-          end
-
-          space_map._mark_cells_occupied(left, top, right, bottom)
-
-          local frame = hs.geometry.rect({
-            x1 = space_map.xs[left],
-            y1 = space_map.ys[top],
-            x2 = space_map.xs[right+1] - 1,
-            y2 = space_map.ys[bottom+1] - 1
-          })
-          if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
-            table.insert(windows, {
-              id = function() return -1 end,
-              frame = function() return frame end,
-              setFrame = function(frame) return end,
-            })
-          end
-        end
+    for _, frame in ipairs(space_map:empty_rects_on_screen(screen:frame())) do
+      if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
+        table.insert(windows, {
+          id = function() return -1 end,
+          frame = function() return frame end,
+          setFrame = function(frame) return end,
+        })
       end
     end
   end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -19,6 +19,37 @@
 ---
 --- Usage example:
 --- ```
+--- local function ignore_notification()
+---   -- ...
+--- end
+--- local function paste_as_keystrokes()
+---   hs.eventtap.keyStrokes(hs.pasteboard.readString())
+--- end
+--- local function rerun_last_command()
+---   hs.execute("kitty @ --to unix:/Users/jfelice/.run/kitty send-text --match=title:kak_repl_window '\x10\x0d'", true)
+--- end
+---
+--- local function focus_window(window)
+---   window:focus()
+---   if hs.window.focusedWindow() ~= window then
+---     -- Some cases with apps having windows on multiple monitors require
+---     -- us to try again (?)
+---     window:focus()
+---   end
+--- end
+---
+--- local function swap_window(window)
+---   local focused_frame = hs.window.focusedWindow():frame()
+---   local selected_frame = window:frame()
+---   hs.window.focusedWindow():setFrame(selected_frame, 0)
+---   window:setFrame(focused_frame, 0)
+--- end
+---
+--- local function stack_window(window)
+---   local frame = window:frame()
+---   hs.window.focusedWindow():setFrame(frame, 0)
+--- end
+---
 --- sigils = hs.loadSpoon("WindowSigils")
 --- sigils:configure({
 ---   hotkeys = {
@@ -31,8 +62,8 @@
 ---   },
 ---   sigil_actions = {
 ---     [{}]       = focus_window,
----     [{'ctrl'}] = swap_window,
----     [{'alt'}]  = warp_window,
+---     [{'ctrl'}] = stack_window,
+---     [{'alt'}]  = swap_window,
 ---   }
 --- })
 --- sigils:start()
@@ -206,7 +237,6 @@ end
 function obj:stop()
   self.window_filter = nil
 end
-
 
 --- WindowSigils:orderedWindows()
 --- Method

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -82,7 +82,7 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 --- WindowSigils.logger
 --- Variable
 --- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
-obj.logger = hs.logger.new('WindowSigils')
+obj.logger = hs.logger.new('WindowSigils', 'debug')
 
 obj.sigils = {
   "a", "b", "c", "d", "e", "f", "g", "i", "m", "n", "o", "p", "q", "r", "s", "t", "u",
@@ -284,10 +284,12 @@ function obj:_addEmptySpaceWindows(windows)
       return subtract_area(empty_frame, window:frame())
     end)
   end
+  self.logger.d('empty_frames = ', hs.inspect(empty_frames))
   for _, empty_frame in ipairs(empty_frames) do
     table.insert(windows, {
       id = function() return -1 end,
       frame = function() return empty_frame end,
+      sefFrame = function(frame) return end,
     })
   end
 end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -1,11 +1,14 @@
 --- === WindowSigils ===
 ---
---- Assign every window a sigil for quick access.
+--- Assign every window and empty rectangle a sigil for quick access.
 ---
---- A letter or digit is rendered in the titlebar of every window, and actions can be bound
---- inside a "sigil" mode with different modifiers.  For example, with no modifiers, the
---- the sigil key can focus the window.  If the 'enter' action is bound to control-w, then
---- 'control-w c' will focus the window with sigil 'c'.
+--- A letter or digit is rendered in the titlebar of every window (or empty space), and
+--- actions can be bound inside the sigil mode and triggered with different modifiers.
+---
+--- For example, with no modifiers, a sigil key can focus the window.  If the 'enter'
+--- action is bound to control-w, then 'control-w c' will focus the window with sigil 'c'.
+--- The action is a function which accepts a window, or in the case of an empty space, a
+--- window-like object which reponds to 'id', 'frame', and 'setFrame'.
 ---
 --- The keys 'h', 'j', 'k', and 'l' are reserved for the window west, south, north, and
 --- east of the currently focused window in standard Vi-like fashion, and so are not
@@ -362,7 +365,7 @@ function obj:_addEmptySpaceWindows(windows)
             table.insert(windows, {
               id = function() return -1 end,
               frame = function() return frame end,
-              sefFrame = function(frame) return end,
+              setFrame = function(frame) return end,
             })
           end
         end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -268,6 +268,9 @@ function obj:_removeUnuseableWindows(windows)
     -- On Big Sur :(
     if bundleID == "com.apple.notificationcenterui" then return false end
     if bundleID == "com.apple.UserNotificationCenter" then return false end
+    -- Other things
+    if bundleID == "com.pop.pop.app" and window:title() == "overlay" then return false end
+    if bundleID == "us.zoom.xos" and window:title() == "" then return false end
     return true
   end)
 end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -277,11 +277,7 @@ function obj:_addEmptySpaceWindows(windows)
             end
           end
 
-          for i = top, bottom do
-            for j = left, right do
-              space_map.occupied[i][j] = true
-            end
-          end
+          space_map._mark_cells_occupied(left, top, right, bottom)
 
           local frame = hs.geometry.rect({
             x1 = space_map.xs[left],

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -247,17 +247,7 @@ local MINIMUM_EMPTY_SIZE = 20
 
 function obj:_addEmptySpaceWindows(windows)
   -- Make a grid with all window boundaries
-  local space_map = SpaceMap:new()
-
-  for _, screen in ipairs(hs.screen.allScreens()) do
-    space_map:add_frame(screen:frame())
-  end
-  for _, window in ipairs(windows) do
-    space_map:add_frame(window:frame())
-  end
-
-  space_map.xs:sort()
-  space_map.ys:sort()
+  local space_map = SpaceMap:new(hs.screen.allScreens(), windows)
 
   -- mark non-empty portions
   local occupied = {}

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -72,6 +72,8 @@
 --- sigils:start()
 --- ```
 
+local CoordinateSet = dofile(hs.spoons.resourcePath("coordinate_set.lua"))
+
 local obj={}
 obj.__index = obj
 
@@ -242,59 +244,6 @@ function obj:stop()
 end
 
 local MINIMUM_EMPTY_SIZE = 20
-
-local CoordinateSet = {}
-
-function CoordinateSet:new()
-  local o = {
-    coordinates = {},
-    xref = {},
-  }
-  setmetatable(o, self)
-  return o
-end
-
-function CoordinateSet:add(coordinate)
-  if not self.xref[coordinate] then
-    self.xref[coordinate] = true
-    table.insert(self.coordinates, coordinate)
-  end
-end
-
-function CoordinateSet:sort()
-  table.sort(self.coordinates)
-end
-
-function CoordinateSet:__index(i)
-  if type(i) == "number" then
-    return self.coordinates[i]
-  end
-  return CoordinateSet[i]
-end
-
-function CoordinateSet:__len()
-  return #self.coordinates
-end
-
-function CoordinateSet:offset(value)
-  if not self.xref[value] then
-    return nil
-  end
-  local lo = 1
-  local hi = #self.coordinates
-  local mid
-  while lo <= hi do
-    mid = hs.math.floor((lo + hi) / 2)
-    if self.coordinates[mid] == value then
-      return mid
-    elseif self.coordinates[mid] < value then
-      lo = mid + 1
-    else
-      hi = mid - 1
-    end
-  end
-  return mid
-end
 
 function obj:_addEmptySpaceWindows(windows)
   -- Make a grid with all window boundaries

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -85,7 +85,7 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 --- WindowSigils.logger
 --- Variable
 --- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
-obj.logger = hs.logger.new('WindowSigils', 'debug')
+obj.logger = hs.logger.new('WindowSigils')
 
 obj.sigils = {
   "a", "b", "c", "d", "e", "f", "g", "i", "m", "n", "o", "p", "q", "r", "s", "t", "u",

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -251,7 +251,6 @@ function CoordinateSet:new()
     xref = {},
   }
   setmetatable(o, self)
-  self.__index = self
   return o
 end
 
@@ -264,6 +263,17 @@ end
 
 function CoordinateSet:sort()
   table.sort(self.coordinates)
+end
+
+function CoordinateSet:__index(i)
+  if type(i) == "number" then
+    return self.coordinates[i]
+  end
+  return CoordinateSet[i]
+end
+
+function CoordinateSet:__len()
+  return #self.coordinates
 end
 
 function CoordinateSet:offset(value)
@@ -369,10 +379,10 @@ function obj:_addEmptySpaceWindows(windows)
           end
 
           local frame = hs.geometry.rect({
-            x1 = xs.coordinates[left],
-            y1 = ys.coordinates[top],
-            x2 = xs.coordinates[right+1] - 1,
-            y2 = ys.coordinates[bottom+1] - 1
+            x1 = xs[left],
+            y1 = ys[top],
+            x2 = xs[right+1] - 1,
+            y2 = ys[bottom+1] - 1
           })
           if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
             table.insert(windows, {

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -404,4 +404,23 @@ function obj:refresh()
   end
 end
 
+function obj:dump()
+  local result = ""
+  for _, sigil in ipairs(self.sigils) do
+    local window = self:window(sigil)
+    if window ~= nil then
+      local app = window:application()
+      local bundleID = "<no app>"
+      if app ~= nil then
+        bundleID = app:bundleID()
+      end
+      local frame = window:frame()
+      result = string.format("%s %s) %5.0f,%5.0f,%5.0f,%5.0f  %-35s %s\n", result, sigil,
+                             frame.x1, frame.y1, frame.x2, frame.y2,
+                             bundleID, window:title())
+    end
+  end
+  return result
+end
+
 return obj

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -249,32 +249,6 @@ function obj:_addEmptySpaceWindows(windows)
   -- Make a grid with all window boundaries
   local space_map = SpaceMap:new(hs.screen.allScreens(), windows)
 
-  -- mark non-empty portions
-  local occupied = {}
-  for i = 1, #space_map.ys do
-    occupied[i] = {}
-    for j = 1, #space_map.xs do
-      occupied[i][j] = false
-    end
-  end
-
-  for _, window in ipairs(windows) do
-    local frame = window:frame()
-
-    local x_start = space_map.xs:offset(frame.x1)
-    local y_start = space_map.ys:offset(frame.y1)
-    local x_end = space_map.xs:offset(frame.x2 + 1)
-    local y_end = space_map.ys:offset(frame.y2 + 1)
-
-    if x_start ~= nil and y_start ~= nil and x_end ~= nil and y_end ~= nil then
-      for j=x_start, x_end - 1, 1 do
-        for i=y_start, y_end - 1, 1 do
-          occupied[i][j] = true
-        end
-      end
-    end
-  end
-
   -- find largest empty rectangles, prefer extending down
   for _, screen in ipairs(hs.screen.allScreens()) do
     local screen_frame = screen:frame()
@@ -285,17 +259,17 @@ function obj:_addEmptySpaceWindows(windows)
 
     for top = i_start, i_end do
       for left = j_start, j_end do
-        if not occupied[top][left] then
+        if not space_map.occupied[top][left] then
 
           local bottom = top
-          while bottom + 1 <= i_end and not occupied[bottom + 1][left] do
+          while bottom + 1 <= i_end and not space_map.occupied[bottom + 1][left] do
             bottom = bottom + 1
           end
 
           local right = nil
           for i = top, bottom do
             local row_right = left
-            while row_right + 1 <= j_end and not occupied[i][row_right + 1] do
+            while row_right + 1 <= j_end and not space_map.occupied[i][row_right + 1] do
               row_right = row_right + 1
             end
             if right == nil or row_right < right then
@@ -305,7 +279,7 @@ function obj:_addEmptySpaceWindows(windows)
 
           for i = top, bottom do
             for j = left, right do
-              occupied[i][j] = true
+              space_map.occupied[i][j] = true
             end
           end
 

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -72,6 +72,7 @@
 --- sigils:start()
 --- ```
 
+local EmptyWindow = dofile(hs.spoons.resourcePath("empty_window.lua"))
 local SpaceMap = dofile(hs.spoons.resourcePath("space_map.lua"))
 
 local obj={}
@@ -251,12 +252,7 @@ function obj:_addEmptySpaceWindows(windows)
   for _, screen in ipairs(screens) do
     for _, frame in ipairs(space_map:empty_rects_on_screen(screen:frame())) do
       if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
-        table.insert(windows, {
-          id = function() return -1 end,
-          frame = function() return frame end,
-          setFrame = function(frame) return end,
-          isVisible = function() return true end,
-        })
+        table.insert(windows, EmptyWindow:new(frame))
       end
     end
   end

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -246,11 +246,9 @@ end
 local MINIMUM_EMPTY_SIZE = 20
 
 function obj:_addEmptySpaceWindows(windows)
-  -- Make a grid with all window boundaries
-  local space_map = SpaceMap:new(hs.screen.allScreens(), windows)
-
-  -- find largest empty rectangles, prefer extending down
-  for _, screen in ipairs(hs.screen.allScreens()) do
+  local screens = hs.screen.allScreens()
+  local space_map = SpaceMap:new(screens, windows)
+  for _, screen in ipairs(screens) do
     for _, frame in ipairs(space_map:empty_rects_on_screen(screen:frame())) do
       if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
         table.insert(windows, {
@@ -261,7 +259,6 @@ function obj:_addEmptySpaceWindows(windows)
       end
     end
   end
-
 end
 
 --- WindowSigils:orderedWindows()

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -274,7 +274,7 @@ function obj:refresh()
     end
 
     local new_elements = {}
-    local windows = sigils:orderedWindows()
+    local windows = self:orderedWindows()
     for i, window in ipairs(windows) do
       local wframe = window:frame()
       table.insert(new_elements, {

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -72,7 +72,7 @@
 --- sigils:start()
 --- ```
 
-local CoordinateSet = dofile(hs.spoons.resourcePath("coordinate_set.lua"))
+local SpaceMap = dofile(hs.spoons.resourcePath("space_map.lua"))
 
 local obj={}
 obj.__index = obj
@@ -247,14 +247,13 @@ local MINIMUM_EMPTY_SIZE = 20
 
 function obj:_addEmptySpaceWindows(windows)
   -- Make a grid with all window boundaries
-  local xs = CoordinateSet:new()
-  local ys = CoordinateSet:new()
+  local space_map = SpaceMap:new()
 
   function add_frame(frame)
-    xs:add(frame.x1)
-    xs:add(frame.x2 + 1)
-    ys:add(frame.y1)
-    ys:add(frame.y2 + 1)
+    space_map.xs:add(frame.x1)
+    space_map.xs:add(frame.x2 + 1)
+    space_map.ys:add(frame.y1)
+    space_map.ys:add(frame.y2 + 1)
   end
 
   for _, screen in ipairs(hs.screen.allScreens()) do
@@ -264,14 +263,14 @@ function obj:_addEmptySpaceWindows(windows)
     add_frame(window:frame())
   end
 
-  xs:sort()
-  ys:sort()
+  space_map.xs:sort()
+  space_map.ys:sort()
 
   -- mark non-empty portions
   local occupied = {}
-  for i = 1, #ys do
+  for i = 1, #space_map.ys do
     occupied[i] = {}
-    for j = 1, #xs do
+    for j = 1, #space_map.xs do
       occupied[i][j] = false
     end
   end
@@ -279,10 +278,10 @@ function obj:_addEmptySpaceWindows(windows)
   for _, window in ipairs(windows) do
     local frame = window:frame()
 
-    local x_start = xs:offset(frame.x1)
-    local y_start = ys:offset(frame.y1)
-    local x_end = xs:offset(frame.x2 + 1)
-    local y_end = ys:offset(frame.y2 + 1)
+    local x_start = space_map.xs:offset(frame.x1)
+    local y_start = space_map.ys:offset(frame.y1)
+    local x_end = space_map.xs:offset(frame.x2 + 1)
+    local y_end = space_map.ys:offset(frame.y2 + 1)
 
     if x_start ~= nil and y_start ~= nil and x_end ~= nil and y_end ~= nil then
       for j=x_start, x_end - 1, 1 do
@@ -296,10 +295,10 @@ function obj:_addEmptySpaceWindows(windows)
   -- find largest empty rectangles, prefer extending down
   for _, screen in ipairs(hs.screen.allScreens()) do
     local screen_frame = screen:frame()
-    local i_start = ys:offset(screen_frame.y)
-    local j_start = xs:offset(screen_frame.x)
-    local i_end = ys:offset(screen_frame.y2 + 1) - 1
-    local j_end = xs:offset(screen_frame.x2 + 1) - 1
+    local i_start = space_map.ys:offset(screen_frame.y)
+    local j_start = space_map.xs:offset(screen_frame.x)
+    local i_end = space_map.ys:offset(screen_frame.y2 + 1) - 1
+    local j_end = space_map.xs:offset(screen_frame.x2 + 1) - 1
 
     for top = i_start, i_end do
       for left = j_start, j_end do
@@ -328,10 +327,10 @@ function obj:_addEmptySpaceWindows(windows)
           end
 
           local frame = hs.geometry.rect({
-            x1 = xs[left],
-            y1 = ys[top],
-            x2 = xs[right+1] - 1,
-            y2 = ys[bottom+1] - 1
+            x1 = space_map.xs[left],
+            y1 = space_map.ys[top],
+            x2 = space_map.xs[right+1] - 1,
+            y2 = space_map.ys[bottom+1] - 1
           })
           if frame.w >= MINIMUM_EMPTY_SIZE and frame.h >= MINIMUM_EMPTY_SIZE then
             table.insert(windows, {

--- a/Source/WindowSigils.spoon/init.lua
+++ b/Source/WindowSigils.spoon/init.lua
@@ -255,6 +255,7 @@ function obj:_addEmptySpaceWindows(windows)
           id = function() return -1 end,
           frame = function() return frame end,
           setFrame = function(frame) return end,
+          isVisible = function() return true end,
         })
       end
     end
@@ -292,20 +293,21 @@ end
 ---    Can also be 'North', 'East', 'South', or 'West' to find a window related to the
 ---    currently focused window.
 function obj:window(sigil)
+  local windows = self:orderedWindows()
   if type(sigil) == 'number' then
-    return self:orderedWindows()[sigil]
+    return windows[sigil]
   elseif sigil == 'North' then
-    return hs.window.focusedWindow():windowsToNorth(nil, true, true)[1]
+    return hs.window.focusedWindow():windowsToNorth(windows, true, true)[1]
   elseif sigil == 'East' then
-    return hs.window.focusedWindow():windowsToEast(nil, true, true)[1]
+    return hs.window.focusedWindow():windowsToEast(windows, true, true)[1]
   elseif sigil == 'South' then
-    return hs.window.focusedWindow():windowsToSouth(nil, true, true)[1]
+    return hs.window.focusedWindow():windowsToSouth(windows, true, true)[1]
   elseif sigil == 'West' then
-    return hs.window.focusedWindow():windowsToWest(nil, true, true)[1]
+    return hs.window.focusedWindow():windowsToWest(windows, true, true)[1]
   else
     for i,k in ipairs(self.sigils) do
       if k == sigil then
-        return self:orderedWindows()[i]
+        return windows[i]
       end
     end
   end

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -13,4 +13,11 @@ function SpaceMap:new()
   return obj
 end
 
+function SpaceMap:add_frame(frame)
+  self.xs:add(frame.x1)
+  self.xs:add(frame.x2 + 1)
+  self.ys:add(frame.y1)
+  self.ys:add(frame.y2 + 1)
+end
+
 return SpaceMap

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -1,0 +1,16 @@
+
+local CoordinateSet = dofile(hs.spoons.resourcePath("coordinate_set.lua"))
+
+local SpaceMap = {}
+SpaceMap.__index = SpaceMap
+
+function SpaceMap:new()
+  local obj = {
+    xs = CoordinateSet:new(),
+    ys = CoordinateSet:new(),
+  }
+  setmetatable(obj, self)
+  return obj
+end
+
+return SpaceMap

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -24,6 +24,24 @@ function SpaceMap:_add_framed_entities(framed_entities)
   end
 end
 
+function SpaceMap:_mark_cells_occupied(left, top, right, bottom)
+  if left ~= nil and top ~= nil and right ~= nil and bottom ~= nil then
+    for j=left, right - 1, 1 do
+      for i=top, bottom - 1, 1 do
+        self.occupied[i][j] = true
+      end
+    end
+  end
+end
+
+function SpaceMap:_mark_frame_cells_occupied(frame)
+  local left = self.xs:offset(frame.x1)
+  local top = self.ys:offset(frame.y1)
+  local right = self.xs:offset(frame.x2 + 1)
+  local bottom = self.ys:offset(frame.y2 + 1)
+  self:_mark_cells_occupied(left, top, right, bottom)
+end
+
 function SpaceMap:_build_occupied_map(windows)
   self.occupied = {}
   for i = 1, #self.ys do
@@ -34,19 +52,7 @@ function SpaceMap:_build_occupied_map(windows)
   end
 
   for _, window in ipairs(windows) do
-    local frame = window:frame()
-    local left = self.xs:offset(frame.x1)
-    local top = self.ys:offset(frame.y1)
-    local right = self.xs:offset(frame.x2 + 1)
-    local bottom = self.ys:offset(frame.y2 + 1)
-
-    if left ~= nil and top ~= nil and right ~= nil and bottom ~= nil then
-      for j=left, right - 1, 1 do
-        for i=top, bottom - 1, 1 do
-          self.occupied[i][j] = true
-        end
-      end
-    end
+    self:_mark_frame_cells_occupied(window:frame())
   end
 end
 

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -64,18 +64,22 @@ function SpaceMap:_initialize(screens, windows)
   self:_build_occupied_map(windows)
 end
 
+function SpaceMap:_find_row_right_extent(row, left, j_end)
+  local row_right = left
+  while row_right + 1 <= j_end and not self.occupied[row][row_right + 1] do
+    row_right = row_right + 1
+  end
+  return row_right
+end
+
 function SpaceMap:_find_empty_extent(top, left, i_end, j_end)
   local bottom = top
   while bottom + 1 <= i_end and not self.occupied[bottom + 1][left] do
     bottom = bottom + 1
   end
-
   local right = nil
   for i = top, bottom do
-    local row_right = left
-    while row_right + 1 <= j_end and not self.occupied[i][row_right + 1] do
-      row_right = row_right + 1
-    end
+    local row_right = self:_find_row_right_extent(i, left, j_end)
     if right == nil or row_right < right then
       right = row_right
     end

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -11,26 +11,26 @@ function SpaceMap:new(...)
     ys = CoordinateSet:new(),
   }
   setmetatable(obj, self)
-  obj:initialize(...)
+  obj:_initialize(...)
   return obj
 end
 
-function SpaceMap:add_frame(frame)
+function SpaceMap:_add_frame(frame)
   self.xs:add(frame.x1)
   self.xs:add(frame.x2 + 1)
   self.ys:add(frame.y1)
   self.ys:add(frame.y2 + 1)
 end
 
-function SpaceMap:add_framed_entities(framed_entities)
+function SpaceMap:_add_framed_entities(framed_entities)
   for _, framed_entity in ipairs(framed_entities) do
-    self:add_frame(framed_entity:frame())
+    self:_add_frame(framed_entity:frame())
   end
 end
 
-function SpaceMap:initialize(...)
+function SpaceMap:_initialize(...)
   for _, framed_entity_array in ipairs(table.pack(...)) do
-    self:add_framed_entities(framed_entity_array)
+    self:_add_framed_entities(framed_entity_array)
   end
   self.xs:sort()
   self.ys:sort()

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -4,12 +4,14 @@ local CoordinateSet = dofile(hs.spoons.resourcePath("coordinate_set.lua"))
 local SpaceMap = {}
 SpaceMap.__index = SpaceMap
 
-function SpaceMap:new()
+function SpaceMap:new(...)
+  local logger = hs.logger.new('SpaceMap', 'debug')
   local obj = {
     xs = CoordinateSet:new(),
     ys = CoordinateSet:new(),
   }
   setmetatable(obj, self)
+  obj:initialize(...)
   return obj
 end
 
@@ -18,6 +20,20 @@ function SpaceMap:add_frame(frame)
   self.xs:add(frame.x2 + 1)
   self.ys:add(frame.y1)
   self.ys:add(frame.y2 + 1)
+end
+
+function SpaceMap:add_framed_entities(framed_entities)
+  for _, framed_entity in ipairs(framed_entities) do
+    self:add_frame(framed_entity:frame())
+  end
+end
+
+function SpaceMap:initialize(...)
+  for _, framed_entity_array in ipairs(table.pack(...)) do
+    self:add_framed_entities(framed_entity_array)
+  end
+  self.xs:sort()
+  self.ys:sort()
 end
 
 return SpaceMap

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -77,12 +77,10 @@ function SpaceMap:_find_empty_extent(top, left, screen_bottom, screen_right)
   while bottom + 1 <= screen_bottom and not self.occupied[bottom + 1][left] do
     bottom = bottom + 1
   end
-  local right = nil
+  local right = self:_find_row_right_extent(top, left, screen_right)
   for row = top, bottom do
     local row_right = self:_find_row_right_extent(row, left, screen_right)
-    if right == nil or row_right < right then
-      right = row_right
-    end
+    right = hs.math.min(right, row_right)
   end
   return bottom, right
 end

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -35,14 +35,14 @@ function SpaceMap:_build_occupied_map(windows)
 
   for _, window in ipairs(windows) do
     local frame = window:frame()
-    local x_start = self.xs:offset(frame.x1)
-    local y_start = self.ys:offset(frame.y1)
-    local x_end = self.xs:offset(frame.x2 + 1)
-    local y_end = self.ys:offset(frame.y2 + 1)
+    local left = self.xs:offset(frame.x1)
+    local top = self.ys:offset(frame.y1)
+    local right = self.xs:offset(frame.x2 + 1)
+    local bottom = self.ys:offset(frame.y2 + 1)
 
-    if x_start ~= nil and y_start ~= nil and x_end ~= nil and y_end ~= nil then
-      for j=x_start, x_end - 1, 1 do
-        for i=y_start, y_end - 1, 1 do
+    if left ~= nil and top ~= nil and right ~= nil and bottom ~= nil then
+      for j=left, right - 1, 1 do
+        for i=top, bottom - 1, 1 do
           self.occupied[i][j] = true
         end
       end

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -1,4 +1,3 @@
-
 local CoordinateSet = dofile(hs.spoons.resourcePath("coordinate_set.lua"))
 
 local SpaceMap = {}

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -64,22 +64,22 @@ function SpaceMap:_initialize(screens, windows)
   self:_build_occupied_map(windows)
 end
 
-function SpaceMap:_find_row_right_extent(row, left, j_end)
+function SpaceMap:_find_row_right_extent(row, left, screen_right)
   local row_right = left
-  while row_right + 1 <= j_end and not self.occupied[row][row_right + 1] do
+  while row_right + 1 <= screen_right and not self.occupied[row][row_right + 1] do
     row_right = row_right + 1
   end
   return row_right
 end
 
-function SpaceMap:_find_empty_extent(top, left, i_end, j_end)
+function SpaceMap:_find_empty_extent(top, left, screen_bottom, screen_right)
   local bottom = top
-  while bottom + 1 <= i_end and not self.occupied[bottom + 1][left] do
+  while bottom + 1 <= screen_bottom and not self.occupied[bottom + 1][left] do
     bottom = bottom + 1
   end
   local right = nil
-  for i = top, bottom do
-    local row_right = self:_find_row_right_extent(i, left, j_end)
+  for row = top, bottom do
+    local row_right = self:_find_row_right_extent(row, left, screen_right)
     if right == nil or row_right < right then
       right = row_right
     end

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -66,4 +66,46 @@ function SpaceMap:_initialize(screens, windows)
   self:_build_occupied_map(windows)
 end
 
+function SpaceMap:empty_rects_on_screen(screen_frame)
+  local i_start = self.ys:offset(screen_frame.y)
+  local j_start = self.xs:offset(screen_frame.x)
+  local i_end = self.ys:offset(screen_frame.y2 + 1) - 1
+  local j_end = self.xs:offset(screen_frame.x2 + 1) - 1
+
+  local empty_rects = {}
+  for top = i_start, i_end do
+    for left = j_start, j_end do
+      if not self.occupied[top][left] then
+
+        local bottom = top
+        while bottom + 1 <= i_end and not self.occupied[bottom + 1][left] do
+          bottom = bottom + 1
+        end
+
+        local right = nil
+        for i = top, bottom do
+          local row_right = left
+          while row_right + 1 <= j_end and not self.occupied[i][row_right + 1] do
+            row_right = row_right + 1
+          end
+          if right == nil or row_right < right then
+            right = row_right
+          end
+        end
+
+        self._mark_cells_occupied(left, top, right, bottom)
+
+        local frame = hs.geometry.rect({
+          x1 = self.xs[left],
+          y1 = self.ys[top],
+          x2 = self.xs[right+1] - 1,
+          y2 = self.ys[bottom+1] - 1
+        })
+        table.insert(empty_rects, frame)
+      end
+    end
+  end
+  return empty_rects
+end
+
 return SpaceMap

--- a/Source/WindowSigils.spoon/space_map.lua
+++ b/Source/WindowSigils.spoon/space_map.lua
@@ -78,9 +78,8 @@ function SpaceMap:_find_empty_extent(top, left, screen_bottom, screen_right)
     bottom = bottom + 1
   end
   local right = self:_find_row_right_extent(top, left, screen_right)
-  for row = top, bottom do
-    local row_right = self:_find_row_right_extent(row, left, screen_right)
-    right = hs.math.min(right, row_right)
+  for row = top + 1, bottom do
+    right = hs.math.min(right, self:_find_row_right_extent(row, left, screen_right))
   end
   return bottom, right
 end


### PR DESCRIPTION
This incorporates the commit from #239 (thanks @erbridge) , and #239 should partially fix #238.

## Window Stacking

In addition, I had some nice improvements that I never submitted that allow stacking windows nicely.  When two windows have the same position:

1. Use the OS window id when sorting to keep the assigned sigils stable. (It used to depend on tab order, and so they would keep moving around).
2. Prevent the sigil indicators themselves from overlapping on the screen.  They are now spaced out nicely so you can select a window as though it were a kind of tabbed control.

For example:

![WindowSigils](https://user-images.githubusercontent.com/147284/123656233-bb0fba80-d7fd-11eb-9382-6436efb8c0b6.png)

## A Note: Planned Future Features

_Not_ a part of this PR, but coming up in hopefully not more than a few weeks:

* Automatically detect added and removed screens.   Right now it fails to draw labels on new screens. (The workaround is to reload the Hammerspoon config.)
* Add sigils to empty spaces to enable warping a window there.  Algorithm yet to be determined.
* Try to ignore non-focusable windows, specifically Pop adds a window to decorate the screen that should be ignored.

