### PR TITLE
URLDispatcher: fix crash when there is no window

### DIFF
--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -97,7 +97,7 @@ end
 ---  * The parameters (follow to the [httpCallback](http://www.hammerspoon.org/docs/hs.urlevent.html#httpCallback) specification)
 function obj:dispatchURL(scheme, host, params, fullUrl)
    local url = fullUrl
-   local currentApp = hs.window.frontmostWindow():application():name()
+   local currentApp = hs.application.frontmostApplication():name()
    self.logger.df("Dispatching URL '%s' from application %s", url, currentApp)
    if self.decode_slack_redir_urls then
       local newUrl = string.match(url, 'https://slack.redir.net/.*url=(.*)')


### PR DESCRIPTION
```
2021-08-14 22:12:08: *** ERROR: .../qaisjp/.hammerspoon/Spoons/URLDispatcher.spoon/init.lua:97: attempt to index a nil value
stack traceback:
	.../qaisjp/.hammerspoon/Spoons/URLDispatcher.spoon/init.lua:97: in function 'URLDispatcher.dispatchURL'
	.../qaisjp/.hammerspoon/Spoons/URLDispatcher.spoon/init.lua:157: in function 'hs.urlevent.internal.httpCallback'
	(...tail calls...)
	[C]: in function 'xpcall'
	...n.app/Contents/Resources/extensions/hs/urlevent/init.lua:42: in function <...n.app/Contents/Resources/extensions/hs/urlevent/init.lua:35>
```

Reproduce the issue by:

1. minimising all windows
2. opening iTerm
3. Running `sleep 5 && open 'https://github.com'`
4. Minimising iTerm
5. Clicking on the background (so that “Finder” shows in the menu bar)
6. Waiting for the `open` to run


https://www.hammerspoon.org/docs/hs.window.html#frontmostWindow says

> **Returns**
> An `hs.window` object representing the frontmost window, or `nil` if there are no visible windows

And the code wasn't accounting for `nil`.

