### PR TITLE
BingDaily: Add option to download image in UHD resolution

### DIFF
--- a/Source/BingDaily.spoon/docs.json
+++ b/Source/BingDaily.spoon/docs.json
@@ -7,7 +7,17 @@
     "Field": [],
     "Function": [],
     "Method": [],
-    "Variable": [],
+    "Variable": [
+      {
+        "def": "BingDaily.uhd_resolution",
+        "desc": "If `true`, download image in UHD resolution instead of HD. Defaults to `false`.",
+        "doc": "If `true`, download image in UHD resolution instead of HD. Defaults to `false`.",
+        "name": "uhd_resolution",
+        "signature": "BingDaily.uhd_resolution",
+        "stripped_doc": "",
+        "type": "Variable"
+      }
+    ],
     "desc": "Use Bing daily picture as your wallpaper, automatically.",
     "doc": "Use Bing daily picture as your wallpaper, automatically.\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/BingDaily.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/BingDaily.spoon.zip)",
     "items": [],

--- a/Source/BingDaily.spoon/init.lua
+++ b/Source/BingDaily.spoon/init.lua
@@ -9,10 +9,15 @@ obj.__index = obj
 
 -- Metadata
 obj.name = "BingDaily"
-obj.version = "1.0"
+obj.version = "1.1"
 obj.author = "ashfinal <ashfinal@gmail.com>"
 obj.homepage = "https://github.com/Hammerspoon/Spoons"
 obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- BingDaily.uhd_resolution
+--- Variable
+--- If `true`, download image in UHD resolution instead of HD. Defaults to `false`.
+obj.uhd_resolution = false
 
 local function curl_callback(exitCode, stdOut, stdErr)
     if exitCode == 0 then
@@ -38,6 +43,9 @@ local function bingRequest()
             if pcall(function() hs.json.decode(body) end) then
                 local decode_data = hs.json.decode(body)
                 local pic_url = decode_data.images[1].url
+                if obj.uhd_resolution then
+                    pic_url = pic_url:gsub("1920x1080", "UHD")
+                end
                 local pic_name = "pic-temp-spoon.jpg"
                 for k, v in pairs(hs.http.urlParts(pic_url).queryItems) do
                     if v.id then


### PR DESCRIPTION
Bing offers their picture of the day in UHD resolution as well as HD.
Since Macs have high res Retina displays, add an option to the BingDaily
spoon to download the wallpaper image in UHD resolution.

Tested on Macos 11.6 / Macbook Air, Hammerspoon 0.9.91.