### PR TITLE
Update for Asana 1.1 and allow add use of body for new tasks

### DIFF
--- a/Source/Asana.spoon/init.lua
+++ b/Source/Asana.spoon/init.lua
@@ -40,13 +40,16 @@
 -- Setup Environment --
 -----------------------
 -- Create locals for all needed globals so we have access to them
+local pairs,ipairs,type,require = pairs,ipairs,type,require
 
 local stringFormat = string.format
 local hs = {
   fnutils = hs.fnutils,
   http    = hs.http,
   json    = hs.json,
-  notify  = hs.notify
+  notify  = hs.notify,
+  logger  = hs.logger,
+  inspect = hs.inspect
 }
 
 -- Empty environment in this scope, this prevents module from polluting global scope
@@ -67,15 +70,19 @@ local function fetchRequiredIds()
 
   local _, res = hs.http.get(baseUrl .. "/users/me", reqHeader)
   res = hs.json.decode(res)
-  userId = res.data.id
+  userId = res.data.gid
   hs.fnutils.each(
     res.data.workspaces,
     function(x)
-      workspaceIds[x.name] = x.id
+      workspaceIds[x.name] = x.gid
     end
   )
 end
 
+local function getTaskParameter(val, prefix)
+   local v = hs.json.encode(val)
+   return "\"" .. prefix .. "\": " .. v
+end 
 
 ------------
 -- Public --
@@ -84,7 +91,7 @@ end
 
 -- Spoon metadata
 name     = "Asana"
-version  = "0.1" -- obj.version = "0.1"
+version  = "0.2" -- obj.version = "0.1"
 author   = "Malo Bourgon"
 license  = "MIT - https://opensource.org/licenses/MIT"
 homepage = "https://github.com/malob/Asana.spoon"
@@ -95,6 +102,29 @@ homepage = "https://github.com/malob/Asana.spoon"
 --- A "personal access token" for Asana. You can create one here: https://app.asana.com/0/developer-console
 apiKey = ""
 
+
+-- Thanks to mnz
+function tableCopy(tabl)
+   local t = {}
+   for k,v in pairs(tabl) do
+      t[k] = type(v)=="table" and tableCopy(v) or v
+   end 
+   return t
+end
+
+-- Thanks to mnz
+function tableMerge(tbl1,tbl2)
+   local t = {}
+   for k,v in pairs(tbl1) do t[k] = type(v)=="table" and tableCopy(v) or v end
+   for k,v in pairs(tbl2) do t[k] = type(v)=="table" and tableCopy(v) or v end 
+   return t
+end
+
+function getTaskBody(tbl1,tbl2)
+   s = stringFormat('{"data": %s}', hs.json.encode(tableMerge(tbl1,tbl2), false))
+   return s 
+end
+
 --- Asana:createTask(taskName, workspaceName) -> Self
 --- Method
 --- Creates a new task named `taskName` in the workspace `workspaceName`.
@@ -102,7 +132,11 @@ apiKey = ""
 --- Parameters:
 ---  * taskName (String)      - The title of the Asana task.
 ---  * WorkspaceName (String) - The name of the workspace in which to create the task.
+---  * taskParameters (Table) - This is what will be sent as the `data` field of the POST body.
 ---
+---  taskParmeters can be defined in the `configConsts.lua` or be rendered direcly in the 
+---  hammerspoon `init.lua` file where the task is registered.
+--- 
 --- Returns:
 ---  * Self
 ---
@@ -110,26 +144,33 @@ apiKey = ""
 ---  ```
 ---  spoon.Asana.createTask("Do that thing I forgot about", "My Company Workspace")
 ---  ```
-function createTask(self, taskName, workspaceName)
+function createTask(self, taskName, workspaceName, taskParameters)
   if workspaceIds == {} or userId == "" then fetchRequiredIds() end
 
+  log = hs.logger.new('Asana', 'info')
+
+  local endPoint = baseUrl .. "/tasks"
+  local body = getTaskBody({
+     workspace = workspaceIds[workspaceName], name = taskName
+  }, taskParameters)
+
+  -- Add content type so the server will know how to read the body
+  reqHeader = tableMerge(reqHeader, {['Content-Type'] = "application/json; charset=UTF8"})
+  
   hs.http.asyncPost(
-    stringFormat(
-      "%s/tasks?assignee=%i&workspace=%i&name=%s",
-      baseUrl,
-      userId,
-      workspaceIds[workspaceName],
-      hs.http.encodeForQuery(taskName)
-    ),
-    "", -- requires empty body
-    reqHeader,
-    function(code)
-      if code == 201 then
+  endPoint,
+  body,
+  reqHeader,
+  function(code, responseBody)
+     if code == 201 then
         hs.notify.show("Asana", "", "New task added to workspace: " .. workspaceName)
-      else
-        hs.notify.show("Asana", "", "Error adding task")
-      end
-    end
+     else
+        local errorStr = stringFormat("%i: Error adding task.", code)
+        hs.notify.show("Asana", "", errorStr)
+        log.e(errorStr)
+        log.e("responseBody = " .. responseBody)
+     end
+  end
   )
   return self
 end

--- a/Source/Asana.spoon/init.lua
+++ b/Source/Asana.spoon/init.lua
@@ -79,11 +79,6 @@ local function fetchRequiredIds()
   )
 end
 
-local function getTaskParameter(val, prefix)
-   local v = hs.json.encode(val)
-   return "\"" .. prefix .. "\": " .. v
-end 
-
 ------------
 -- Public --
 ------------
@@ -108,7 +103,7 @@ function tableCopy(tabl)
    local t = {}
    for k,v in pairs(tabl) do
       t[k] = type(v)=="table" and tableCopy(v) or v
-   end 
+   end
    return t
 end
 
@@ -116,13 +111,13 @@ end
 function tableMerge(tbl1,tbl2)
    local t = {}
    for k,v in pairs(tbl1) do t[k] = type(v)=="table" and tableCopy(v) or v end
-   for k,v in pairs(tbl2) do t[k] = type(v)=="table" and tableCopy(v) or v end 
+   for k,v in pairs(tbl2) do t[k] = type(v)=="table" and tableCopy(v) or v end
    return t
 end
 
 function getTaskBody(tbl1,tbl2)
    s = stringFormat('{"data": %s}', hs.json.encode(tableMerge(tbl1,tbl2), false))
-   return s 
+   return s
 end
 
 --- Asana:createTask(taskName, workspaceName) -> Self
@@ -134,9 +129,9 @@ end
 ---  * WorkspaceName (String) - The name of the workspace in which to create the task.
 ---  * taskParameters (Table) - This is what will be sent as the `data` field of the POST body.
 ---
----  taskParmeters can be defined in the `configConsts.lua` or be rendered direcly in the 
+---  taskParmeters can be defined in the `configConsts.lua` or be rendered direcly in the
 ---  hammerspoon `init.lua` file where the task is registered.
---- 
+---
 --- Returns:
 ---  * Self
 ---
@@ -156,7 +151,7 @@ function createTask(self, taskName, workspaceName, taskParameters)
 
   -- Add content type so the server will know how to read the body
   reqHeader = tableMerge(reqHeader, {['Content-Type'] = "application/json; charset=UTF8"})
-  
+
   hs.http.asyncPost(
   endPoint,
   body,


### PR DESCRIPTION
The idea is to be able to read the values that changed, such as `id` to `gid`. Also I wanted the ability to easily provide any necessary detail for a new Asana task as defined [here](https://developers.asana.com/docs/create-a-task). To do this easily the body of the POST is populated. 

One can merge a template of task details with other detail to form the `data` object of the POST body.

Example: 

I have a template for inserting the new task into two Asana projects. It is stored in my `configConsts.lua`. 

```lua
 asanaTaskParameters = {
       projects = {
          [1] = "1200536698010895",
          [2] = "1200674652387402"
       }
    }
```

Two things are necessary to make this work. The first is being able to join tables. I could not get the built-in or `hs.fnutils` table tools to work for me. I added a couple of functions that work. I have not tried to improve them. The second thing is simply designating the content type so the Asana service can decode the body of the POST.

```lua
reqHeader = tableMerge(reqHeader, {['Content-Type'] = "application/json; charset=UTF8"})
```

I did not do much with documentation. . . 

Here is an example of how I registered this Asana spoon with `Seal`. (Almost the same as before.)

```lua
                        ,["New Asana task in " .. consts.asanaWorkWorkspaceName] = {
                            fn = function(y) spoon.Asana:createTask(y, consts.asanaWorkWorkspaceName, consts.asanaTaskParameters) end,
                              keyword = "astogo"
                           }
```

I am not sure if it is documented but I am storing the API key in the macOS keychain and retrieve it in the config like this.

```lua
 asanaApiKey = hs.execute("security find-generic-password -w -a ${USER} -s asana-api-key | tr -d '\n'")
```
