### PR TITLE
BingDaily: Add screens and runAt options

### DIFF
--- a/Source/BingDaily.spoon/init.lua
+++ b/Source/BingDaily.spoon/init.lua
@@ -19,15 +19,18 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 --- If `true`, download image in UHD resolution instead of HD. Defaults to `false`.
 obj.uhd_resolution = false
 
+--- BingDaily.screens
+--- Variable
+--- Set this to a function that returns a list of screens on which to configure
+--- the desktop image, instead of hs.screen.allScreens
+obj.screens = hs.screen.allScreens
+
 local function curl_callback(exitCode, stdOut, stdErr)
     if exitCode == 0 then
         obj.task = nil
         obj.last_pic = obj.file_name
         local localpath = os.getenv("HOME") .. "/.Trash/" .. obj.file_name
-
-        -- set wallpaper for all screens
-        allScreen = hs.screen.allScreens()
-        for _,screen in ipairs(allScreen) do
+        for _,screen in ipairs(obj.screens()) do
             screen:desktopImageURL("file://" .. localpath)
         end
     else

--- a/Source/BingDaily.spoon/init.lua
+++ b/Source/BingDaily.spoon/init.lua
@@ -25,6 +25,13 @@ obj.uhd_resolution = false
 --- the desktop image, instead of hs.screen.allScreens
 obj.screens = hs.screen.allScreens
 
+--- BingDaily.runAt
+--- Variable
+--- Set this to a time at which the wallpaper should be refreshed daily, eg,
+--- `"06:00"`. If this is not set, the wallpaper will be updated every 3 hours. If
+--- this is used, you must call `spoon.BingDaily:start()` after configuring.
+obj.runAt = nil
+
 local function curl_callback(exitCode, stdOut, stdErr)
     if exitCode == 0 then
         obj.task = nil
@@ -74,13 +81,24 @@ local function bingRequest()
     end)
 end
 
-function obj:init()
-    if obj.timer == nil then
-        obj.timer = hs.timer.doEvery(3*60*60, function() bingRequest() end)
-        obj.timer:setNextTrigger(5)
+function obj:start()
+    if obj.runAt ~= nil then
+        obj.timer = hs.timer.doAt(obj.runAt, "1d", bingRequest)
     else
-        obj.timer:start()
+        obj.timer = hs.timer.doEvery(3*60*60, bingRequest)
+        obj.timer:setNextTrigger(5)
     end
+end
+
+function obj:init()
+    if obj.timer ~= nil then
+        obj.timer:stop()
+    end
+    obj:start()
+end
+
+function obj:refresh()
+    bingRequest()
 end
 
 return obj

--- a/Source/BingDaily.spoon/init.lua
+++ b/Source/BingDaily.spoon/init.lua
@@ -71,7 +71,7 @@ local function bingRequest()
                         obj.task = nil
                     end
                     local localpath = os.getenv("HOME") .. "/.Trash/" .. obj.file_name
-                    obj.task = hs.task.new("/usr/bin/curl", curl_callback, {"-A", user_agent_str, obj.full_url, "-o", localpath})
+                    obj.task = hs.task.new("/usr/bin/curl", curl_callback, {"-sSf", "-A", user_agent_str, obj.full_url, "-o", localpath})
                     obj.task:start()
                 end
             end


### PR DESCRIPTION
This PR adds two options to BingDaily to allow configuring:

* the screens where the wallpaper should be set
* the time at which the wallpaper should be set every day, to prevent distracting mid-activity wallpaper changes

Also it adds a `spoon.BingDaily:refresh()` method that allows the user to manually refresh the wallpaper on certain events.

Finally it passes `-f` to cURL so that cURL will exit with an error code if the wallpaper server responds with an HTTP error. It also passes `-sS` which causes cURL to be quiet unless there is an error.