### PR TITLE
address Monterey changes causing TimeMachineProgress to error

### DIFF
--- a/Source/TimeMachineProgress.spoon/init.lua
+++ b/Source/TimeMachineProgress.spoon/init.lua
@@ -13,7 +13,7 @@ obj.__index = obj
 
 -- Metadata
 obj.name = "TimeMachineProgress"
-obj.version = "0.1"
+obj.version = "0.2"
 obj.author = "Diego Zamboni <diego@zzamboni.org>"
 obj.homepage = "https://github.com/Hammerspoon/Spoons"
 obj.license = "MIT - https://opensource.org/licenses/MIT"
@@ -132,7 +132,7 @@ function obj:refresh()
 
     -- Identify special states: preparing backup and stopping backup.
     local stopping = (data['Stopping'] == '1')
-    local preparing = (not stopping) and (data['Percent'] == '-1' or data['Percent'] == '0')
+    local preparing = (not stopping) and (data['Percent'] == '-1' or data['Percent'] == '0' or not data['Progress'])
 
     -- Depending on macOS version the 'Progress' data may be stored in a
     -- subitem, we promote it to the top level
@@ -148,7 +148,11 @@ function obj:refresh()
       topmenu = tooltip
     elseif preparing then
       title = "(prep)"
-      tooltip = "Preparing Backup…"
+      if (data['BackupPhase']) then
+        tooltip = data['BackupPhase']:gsub("(%l)(%u)", "%1 %2")
+      else
+        tooltip = "Preparing Backup…"
+      end
       topmenu = tooltip
     else
       title = string.format("%.2f%%", tonumber(data['Percent'])*100)


### PR DESCRIPTION
I noticed after I upgraded to Monterey (12.2 or 12.3, not sure when it started) that TimeMacineProgress would sometimes appear to get stuck at the **(prep)** stage. That was being caused by an error - apparently `tmutil status` now reports intermediate phases that lack any Percent value.  This PR addresses that error, bumps the version, and as a bonus provides a little more info in the (prep) tooltip during the various backup phases provided by the apparently modified tmutil's status results. 

FWIW TimeMachineProgress's percentage stops advancing when TimeMachine goes into its 'cleaning up' phases, prior to 'stopping'. Addressing that is a separate issue that I'm not sure is worth the effort. I'm happy to try to help if you think it is.

Below is an example of the tmutil status data that triggers the stack dump:

```
2022-03-19 21:02:38:                          Backup is running
2022-03-19 21:02:38:                          Setting up menubar title to '(prep)'
2022-03-19 21:02:43: 21:02:43 TimeMachin:     tmutil status output: {
    BackupPhase = FindingChanges;
    ChangedItemCount = 3798;
    ClientID = "com.apple.backupd";
    DateOfStateChange = "2022-03-20 01:02:43 +0000";
    DestinationID = "48BF55E5-E974-4E47-83BE-846AFCB1DB13";
    DestinationMountPoint = "/Volumes/Time Machine Backups";
    EventFractionOfTotalProgressBar = "0.1";
    FractionDone = "0.07953837900431027";
    Running = 1;
    Stopping = 0;
    sizingFreePreflight = 1;
}


2022-03-19 21:02:43:                          Formatted data read by hs.plist: {
  BackupPhase = "FindingChanges",
  ChangedItemCount = "3798",
  ClientID = "com.apple.backupd",
  DateOfStateChange = "2022-03-20 01:02:43 +0000",
  DestinationID = "48BF55E5-E974-4E47-83BE-846AFCB1DB13",
  DestinationMountPoint = "/Volumes/Time Machine Backups",
  EventFractionOfTotalProgressBar = "0.1",
  FractionDone = "0.07953837900431027",
  Running = "1",
  Stopping = "0",
  sizingFreePreflight = "1"
}

2022-03-19 21:02:43:                          Backup is running
2022-03-19 21:02:43: 21:02:43 ERROR:   LuaSkin: hs.timer callback error: ...d/.hammerspoon/Spoons/TimeMachineProgress.spoon/init.lua:154: attempt to perform arithmetic on a nil value
stack traceback:
	...d/.hammerspoon/Spoons/TimeMachineProgress.spoon/init.lua:154: in function 'TimeMachineProgress.refresh'
	...d/.hammerspoon/Spoons/TimeMachineProgress.spoon/init.lua:216: in function <...d/.hammerspoon/Spoons/TimeMachineProgress.spoon/init.lua:216>

```