### PR TITLE
Fix createArrangement dialog msg [spoon.ArrangeDesktop]

### DIFF
--- a/Source/ArrangeDesktop.spoon/init.lua
+++ b/Source/ArrangeDesktop.spoon/init.lua
@@ -202,7 +202,7 @@ function obj:createArrangement()
         return
     end
 
-    hs.dialog.blockAlert("We will now record each of your application windows.", "Each will window will flash into focus. The first focus on each monitor will prompt you to name the monitor.")
+    hs.dialog.blockAlert("We will now record each of your application windows.", "Each window will flash into focus. The first focus on each monitor will prompt you to name the monitor.")
 
     config[arrangementName] = obj:_buildArrangement(arrangementName)
 


### PR DESCRIPTION
Fixes a typo in the dialog message showing before recording of app windows in the ArrangeDesktop spoon