### PR TITLE
fix seal plugins cmd being ignored in commands table

### DIFF
--- a/Source/Seal.spoon/init.lua
+++ b/Source/Seal.spoon/init.lua
@@ -301,9 +301,9 @@ function obj.choicesCallback()
     end
     query_words = table.concat(query_words, " ")
     -- First get any direct command matches
-    for command,cmdInfo in pairs(obj.commands) do
+    for _,cmdInfo in pairs(obj.commands) do
         cmd_fn = cmdInfo["fn"]
-        if cmd:lower() == command:lower() then
+        if cmd:lower() == cmdInfo["cmd"]:lower() then
             if (query_words or "") == "" then
                 query_words = ".*"
             end


### PR DESCRIPTION
Seal plugins can define a table of commands which contains
the command used to launch it in the `cmd` field.

However currently the key of the command in the commands table
is used instead of this field.
This was identical for most seal plugin except filesearch which
uses the special ' character as the command trigger.