### PR TITLE
Fix query replacement for non-spaced queries

### DIFF
--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -276,7 +276,8 @@ function obj.completionCallback(row)
          obj.actions[row.actionname].fn(row.arg)
       elseif obj.actions[row.actionname].url then
          row.arg = hs.http.encodeForQuery(row.arg)
-         local url = string.gsub(obj.actions[row.actionname].url, '${query}', row.arg:gsub("%%", "%%%%"))
+         local query = row.arg:gsub("%%", "%%%%")
+         local url = string.gsub(obj.actions[row.actionname].url, '${query}', query)
          obj.openURL(url)
       end
    end


### PR DESCRIPTION
### Bug

When querying a single word (without spaces), the substitution string `${query}` won't be replaced.

### Explanation/Fix
`string.gsub` returns two values: the string with substitutions and the number of substitutions made

If doing the nested `gsub`, these two return values will be passed into the outer `gsub`, which accepts an optional fourth parameter specifying how many substitutions should be made. So the number of substitutions in the inner `gsub` determines the number of substitutions in the outer `gsub`: When the query doesn't contain a blank, that number of substitutions in the inner `gsub` is `0` and the outer `gsub` won't replace anything, leaving `${query}` in the `url`.

By first assigning the `gsub` result to a variable, the number of substitutions return value will be ignored.