### PR TITLE
URLDispatcher: Improvements in patterns and function URL handlers

### DIFF
--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -190,19 +190,20 @@ function obj:dispatchURL(scheme, host, params, fullUrl, senderPid)
       end
    end
    for i,dec in ipairs(self.url_redir_decoders) do
-     self.logger.df("  Testing decoder '%s'", dec[1])
-     if self.matchapps(currentApp, dec[5]) then
-       if string.find(url, dec[2]) then
-         self.logger.df("    Applying decoder '%s' to URL '%s'", dec[1], url)
-         url = string.gsub(url, dec[2], dec[3])
-         self.logger.df("    Decoded URL: '%s'", url)
-         if not dec[4] then
-           self.logger.df("    Unescaping decoded URL '%s'", url)
-           url = obj.unescape(url)
-           self.logger.df("    Unescaped URL: '%s'", url)
+      self.logger.df("  Testing decoder '%s'", dec[1])
+      if self.matchapps(currentApp, dec[5]) then
+
+         if string.find(url, dec[2]) then
+            self.logger.df("    Applying decoder '%s' to URL '%s'", dec[1], url)
+            url = string.gsub(url, dec[2], dec[3])
+            self.logger.df("    Decoded URL: '%s'", url)
+            if not dec[4] then
+               self.logger.df("    Unescaping decoded URL '%s'", url)
+               url = obj.unescape(url)
+               self.logger.df("    Unescaped URL: '%s'", url)
+            end
          end
-       end
-     end
+      end
    end
    self.logger.df("Final URL to open: '%s'", url)
    for i,pair in ipairs(self.url_patterns) do

--- a/Source/URLDispatcher.spoon/init.lua
+++ b/Source/URLDispatcher.spoon/init.lua
@@ -52,7 +52,6 @@ obj.url_redir_decoders = { }
 --- URL dispatch rules.
 ---
 --- Notes:
-
 ---  * A table containing a list of dispatch rules. Each rule should be its own
 ---    table in the format: `{ url-patterns, app-bundle-ID-or-function, function }`,
 ---    and they are evaluated in the order they are declared.


### PR DESCRIPTION
Multiple improvements:

- default_handler can now also be a function in addition to a bundle ID.  If a function is given, it is called with the URL.

- In url_patterns, the second value of each element can now be both a string (interpreted as a bundle ID) or a function (called with the URL). A function can also be specified as the third value, for backwards compatibility, so existing configurations should not break.

- In url_patterns, the first value of each element can now be both a string  (a single pattern), a table containing a list of patterns, or a filename from which  the list of patterns to match will be read. Furthermore, a watcher is set  so that the patterns are automatically reloaded if the file changes.

- In url_patterns, the last element of each rule can be an app name pattern  (or a list of them). If given, the rule will only be evaluated for URLs opened  from applications matching any of the patterns.

- In url_redir_decoders, the second element can now be a function, in which  case the URL information is passed to the function, and the returned value  is used as the URL to dispatch.
