### PR TITLE
New Spoon: AppWindowSwitcher

### DIFF
--- a/Source/AppWindowSwitcher.spoon/docs.json
+++ b/Source/AppWindowSwitcher.spoon/docs.json
@@ -1,0 +1,111 @@
+[
+  {
+    "Command": [],
+    "Constant": [],
+    "Constructor": [],
+    "Deprecated": [],
+    "Field": [],
+    "Function": [],
+    "Method": [
+      {
+        "def": "AppWindowSwitcher:bindHotkeys(mapping) -> self",
+        "desc": "Binds hotkeys for AppWindowSwitcher",
+        "doc": "Binds hotkeys for AppWindowSwitcher\n\nParameters:\n * mapping - A table containing hotkey modifier/key details for each application to manage \n\nNotes:\nThe mapping table accepts these formats per table element:\n* A single text to match:\n  `[\"<matchtext>\"] = {mods, key}` \n* A list of texts, to assign multiple applications to one hotkey:\n  `[{\"<matchtext>\", \"<matchtext>\", ...}] = {mods, key}`\n* `<matchtext>` can be either a bundleID, or a text which is substring matched against a windows application title start. \n\nReturns:\n * The AppWindowSwitcher object",
+        "examples": [],
+        "file": "./init.lua",
+        "lineno": "92",
+        "name": "bindHotkeys",
+        "notes": [
+          "The mapping table accepts these formats per table element:",
+          "* A single text to match:",
+          "  `[\"<matchtext>\"] = {mods, key}` ",
+          "* A list of texts, to assign multiple applications to one hotkey:",
+          "  `[{\"<matchtext>\", \"<matchtext>\", ...}] = {mods, key}`",
+          "* `<matchtext>` can be either a bundleID, or a text which is substring matched against a windows application title start. "
+        ],
+        "parameters": [
+          " * mapping - A table containing hotkey modifier/key details for each application to manage"
+        ],
+        "returns": [
+          " * The AppWindowSwitcher object"
+        ],
+        "signature": "AppWindowSwitcher:bindHotkeys(mapping) -> self",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "AppWindowSwitcher:setLogLevel(level) -> self",
+        "desc": "Set the log level of the spoon logger.",
+        "doc": "Set the log level of the spoon logger.\n\nParameters:\n * Log level - `\"debug\"` to enable console debug output\n\nReturns:\n * The AppWindowSwitcher object",
+        "examples": [],
+        "file": "./init.lua",
+        "lineno": "151",
+        "name": "setLogLevel",
+        "notes": [],
+        "parameters": [
+          " * Log level - `\"debug\"` to enable console debug output"
+        ],
+        "returns": [
+          " * The AppWindowSwitcher object"
+        ],
+        "signature": "AppWindowSwitcher:setLogLevel(level) -> self",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "Variable": [],
+    "desc": "macOS application aware, keyboard driven window switcher. Spoon ",
+    "doc": "macOS application aware, keyboard driven window switcher. Spoon \non top of Hammerspoon.\n\nSwitches windows by focusing and raising them. All windows matching a \nbundelID, a list of bundleID's, an application name matchtext, \nor a list of application name matchtexts are switched by cycling \nthem. Cycling applies to visible windows of currently focused space \nonly. The spoon does not launch applications, it operates on open \nwindows of running applications.\n\nExample `~/.hammerspoon/init.lua` configuration:\n\n```\nhs.loadSpoon(\"AppWindowSwitcher\")\n    -- :setLogLevel(\"debug\") -- uncomment for console debug log\n    :bindHotkeys({\n        [\"com.apple.Terminal\"]        = {hyper, \"t\"},\n        [{\"com.apple.Safari\",\n          \"com.google.Chrome\",\n          \"com.kagi.kagimacOS\",\n          \"com.microsoft.edgemac\", \n          \"org.mozilla.firefox\"}]     = {hyper, \"q\"},\n        [\"Hammerspoon\"]               = {hyper, \"h\"},\n        [{\"O\", \"o\"}]                  = {hyper, \"o\"},\n    })\n```\nIn this example, \n* `hyper-t` cycles all terminal windows (matching a single bundleID),\n* `hyper-q` cycles all windows of the five browsers (matching either \n  of the bundleIDs)\n* `hyper-h` brings the Hammerspoon console forward (matching the \n  application title),\n* `hyper-o` cycles all windows whose application title starts \n  with \"O\" or \"o\".\n\nThe cycling logic works as follows:\n* If the focused window is part of the application matching a hotkey,\n  then the last window (in terms of macOS windows stacking) of the matching \n  application(s) will be brought forward and focused.\n* If the focused window is not part of the application matching a\n  hotkey, then the first window (in terms of macOS windows stacking) i\n  of the matching applications will be brought forward and focused.",
+    "items": [
+      {
+        "def": "AppWindowSwitcher:bindHotkeys(mapping) -> self",
+        "desc": "Binds hotkeys for AppWindowSwitcher",
+        "doc": "Binds hotkeys for AppWindowSwitcher\n\nParameters:\n * mapping - A table containing hotkey modifier/key details for each application to manage \n\nNotes:\nThe mapping table accepts these formats per table element:\n* A single text to match:\n  `[\"<matchtext>\"] = {mods, key}` \n* A list of texts, to assign multiple applications to one hotkey:\n  `[{\"<matchtext>\", \"<matchtext>\", ...}] = {mods, key}`\n* `<matchtext>` can be either a bundleID, or a text which is substring matched against a windows application title start. \n\nReturns:\n * The AppWindowSwitcher object",
+        "examples": [],
+        "file": "./init.lua",
+        "lineno": "92",
+        "name": "bindHotkeys",
+        "notes": [
+          "The mapping table accepts these formats per table element:",
+          "* A single text to match:",
+          "  `[\"<matchtext>\"] = {mods, key}` ",
+          "* A list of texts, to assign multiple applications to one hotkey:",
+          "  `[{\"<matchtext>\", \"<matchtext>\", ...}] = {mods, key}`",
+          "* `<matchtext>` can be either a bundleID, or a text which is substring matched against a windows application title start. "
+        ],
+        "parameters": [
+          " * mapping - A table containing hotkey modifier/key details for each application to manage"
+        ],
+        "returns": [
+          " * The AppWindowSwitcher object"
+        ],
+        "signature": "AppWindowSwitcher:bindHotkeys(mapping) -> self",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "AppWindowSwitcher:setLogLevel(level) -> self",
+        "desc": "Set the log level of the spoon logger.",
+        "doc": "Set the log level of the spoon logger.\n\nParameters:\n * Log level - `\"debug\"` to enable console debug output\n\nReturns:\n * The AppWindowSwitcher object",
+        "examples": [],
+        "file": "./init.lua",
+        "lineno": "151",
+        "name": "setLogLevel",
+        "notes": [],
+        "parameters": [
+          " * Log level - `\"debug\"` to enable console debug output"
+        ],
+        "returns": [
+          " * The AppWindowSwitcher object"
+        ],
+        "signature": "AppWindowSwitcher:setLogLevel(level) -> self",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "name": "AppWindowSwitcher",
+    "stripped_doc": "on top of Hammerspoon.\n\nSwitches windows by focusing and raising them. All windows matching a \nbundelID, a list of bundleID's, an application name matchtext, \nor a list of application name matchtexts are switched by cycling \nthem. Cycling applies to visible windows of currently focused space \nonly. The spoon does not launch applications, it operates on open \nwindows of running applications.\n\nExample `~/.hammerspoon/init.lua` configuration:\n\n```\nhs.loadSpoon(\"AppWindowSwitcher\")\n    -- :setLogLevel(\"debug\") -- uncomment for console debug log\n    :bindHotkeys({\n        [\"com.apple.Terminal\"]        = {hyper, \"t\"},\n        [{\"com.apple.Safari\",\n          \"com.google.Chrome\",\n          \"com.kagi.kagimacOS\",\n          \"com.microsoft.edgemac\", \n          \"org.mozilla.firefox\"}]     = {hyper, \"q\"},\n        [\"Hammerspoon\"]               = {hyper, \"h\"},\n        [{\"O\", \"o\"}]                  = {hyper, \"o\"},\n    })\n```\nIn this example, \n* `hyper-t` cycles all terminal windows (matching a single bundleID),\n* `hyper-q` cycles all windows of the five browsers (matching either \n  of the bundleIDs)\n* `hyper-h` brings the Hammerspoon console forward (matching the \n  application title),\n* `hyper-o` cycles all windows whose application title starts \n  with \"O\" or \"o\".\n\nThe cycling logic works as follows:\n* If the focused window is part of the application matching a hotkey,\n  then the last window (in terms of macOS windows stacking) of the matching \n  application(s) will be brought forward and focused.\n* If the focused window is not part of the application matching a\n  hotkey, then the first window (in terms of macOS windows stacking) i\n  of the matching applications will be brought forward and focused.",
+    "submodules": [],
+    "type": "Module"
+  }
+]

--- a/Source/AppWindowSwitcher.spoon/init.lua
+++ b/Source/AppWindowSwitcher.spoon/init.lua
@@ -1,0 +1,165 @@
+--- === AppWindowSwitcher ===
+---
+--- macOS application aware, keyboard driven window switcher. Spoon 
+--- on top of Hammerspoon.
+---
+--- Switches windows by focusing and raising them. All windows matching a 
+--- bundelID, a list of bundleID's, an application name matchtext, 
+--- or a list of application name matchtexts are switched by cycling 
+--- them. Cycling applies to visible windows of currently focused space 
+--- only. The spoon does not launch applications, it operates on open 
+--- windows of running applications.
+---
+--- Example `~/.hammerspoon/init.lua` configuration:
+---
+--- ```
+--- hs.loadSpoon("AppWindowSwitcher")
+---     -- :setLogLevel("debug") -- uncomment for console debug log
+---     :bindHotkeys({
+---         ["com.apple.Terminal"]        = {hyper, "t"},
+---         [{"com.apple.Safari",
+---           "com.google.Chrome",
+---           "com.kagi.kagimacOS",
+---           "com.microsoft.edgemac", 
+---           "org.mozilla.firefox"}]     = {hyper, "q"},
+---         ["Hammerspoon"]               = {hyper, "h"},
+---         [{"O", "o"}]                  = {hyper, "o"},
+---     })
+--- ```
+--- In this example, 
+--- * `hyper-t` cycles all terminal windows (matching a single bundleID),
+--- * `hyper-q` cycles all windows of the five browsers (matching either 
+---   of the bundleIDs)
+--- * `hyper-h` brings the Hammerspoon console forward (matching the 
+---   application title),
+--- * `hyper-o` cycles all windows whose application title starts 
+---   with "O" or "o".
+---
+--- The cycling logic works as follows:
+--- * If the focused window is part of the application matching a hotkey,
+---   then the last window (in terms of macOS windows stacking) of the matching 
+---   application(s) will be brought forward and focused.
+--- * If the focused window is not part of the application matching a
+---   hotkey, then the first window (in terms of macOS windows stacking) i
+---   of the matching applications will be brought forward and focused.
+
+require("hs.hotkey")
+require("hs.window")
+require("hs.inspect")
+require("hs.fnutils")
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "AppWindowSwitcher"
+obj.version = "0.0"
+obj.author = "B Viefhues"
+obj.homepage = "https://github.com/bviefhues/AppWindowSwitcher.spoon"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+
+-- AppWindowSwitcher.log
+-- Variable
+-- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.log = hs.logger.new("AppWindowSwitcher")
+
+-- prefix match for text. Returns true if text starts with prefix.
+function obj.startswith(text, prefix)
+    return text:find(prefix, 1, true) == 1
+end
+
+-- Matches window properties with matchtexts array of texts
+-- Returns true if:
+-- * windows application bundleID is an element of matchtexts, or
+-- * windows application title starts with an element of matchtext
+function obj.match(window, matchtexts)
+    bundleID = window:application():bundleID()
+    if hs.fnutils.contains(matchtexts, bundleID) then
+        obj.log.d("bundleID matches:", bundleID)
+        return true
+    end
+    title = window:application():title()
+    for _, matchtext in pairs(matchtexts) do
+        if obj.startswith(title, matchtext) then
+            obj.log.d("title matches:", title, matchtext)
+            return true
+        end
+    end
+    return false
+end
+
+--- AppWindowSwitcher:bindHotkeys(mapping) -> self
+--- Method
+--- Binds hotkeys for AppWindowSwitcher
+---
+--- Parameters:
+---  * mapping - A table containing hotkey modifier/key details for each application to manage 
+---
+--- Notes:
+--- The mapping table accepts these formats per table element:
+--- * A single text to match:
+---   `["<matchtext>"] = {mods, key}` 
+--- * A list of texts, to assign multiple applications to one hotkey:
+---   `[{"<matchtext>", "<matchtext>", ...}] = {mods, key}`
+--- * `<matchtext>` can be either a bundleID, or a text which is substring matched against a windows application title start. 
+---
+--- Returns:
+---  * The AppWindowSwitcher object
+function obj:bindHotkeys(mapping)
+    for matchtexts, modsKey in pairs(mapping) do
+        obj.log.d("Mapping " .. hs.inspect(matchtexts) .. 
+                  " to " .. hs.inspect(modsKey))
+
+        if type(matchtexts) == "string" then
+            matchtexts = {matchtexts} -- further code assumes a table
+        end
+        mods, key = table.unpack(modsKey)
+        hs.hotkey.bind(mods, key, function() 
+            local focusedWindowBundleID = 
+                hs.window.focusedWindow():application():bundleID() 
+
+            newW = nil
+            if obj.match(hs.window.focusedWindow(), matchtexts) then
+                -- app has focus, find last matching window
+                for _, w in pairs(hs.window.orderedWindows()) do
+                    if obj.match(w, matchtexts) then
+                        newW = w -- remember last match
+                    end
+                end
+            else
+                -- app does not have focus, find first matching window
+                for _, w in pairs(hs.window.orderedWindows()) do
+                    if obj.match(w, matchtexts) then
+                        newW = w
+                        break -- break on first match
+                    end
+                end
+            end
+            if newW then
+                newW:raise():focus()
+            else
+                hs.alert.show("No window open for " .. 
+                    hs.inspect(matchtexts))
+            end
+        end)
+    end
+
+    return self
+end
+
+--- AppWindowSwitcher:setLogLevel(level) -> self
+--- Method
+--- Set the log level of the spoon logger.
+---
+--- Parameters:
+---  * Log level - `"debug"` to enable console debug output
+---
+--- Returns:
+---  * The AppWindowSwitcher object
+function obj:setLogLevel(level)
+    obj.log.setLogLevel(level)
+    return self
+end
+
+return obj


### PR DESCRIPTION
Application aware, keyboard driven window switcher.

Switches windows by focusing and raising them. All windows matching a bundelID, a list of bundleID's, an application name matchtext, or a list of application name matchtexts are switched by cycling them.