### PR TITLE
update showyedge web address

### DIFF
--- a/Source/MenubarFlag.spoon/docs.json
+++ b/Source/MenubarFlag.spoon/docs.json
@@ -182,7 +182,7 @@
       }
     ],
     "desc": "Color the menubar according to the current keyboard layout",
-    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
+    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
     "items": [
       {
         "def": "MenubarFlag.allScreens",
@@ -357,7 +357,7 @@
       }
     ],
     "name": "MenubarFlag",
-    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
+    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
     "submodules": [],
     "type": "Module"
   }

--- a/Source/MenubarFlag.spoon/init.lua
+++ b/Source/MenubarFlag.spoon/init.lua
@@ -4,7 +4,8 @@
 ---
 --- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)
 ---
---- Functionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)
+--- Functionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)
+
 
 local obj={}
 obj.__index = obj

--- a/docs/MenubarFlag.html
+++ b/docs/MenubarFlag.html
@@ -17,7 +17,7 @@
       <h1><a href="./index.html">docs</a> &raquo; MenubarFlag</h1>
       <p>Color the menubar according to the current keyboard layout</p>
 <p>Download: <a href="https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip">https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip</a></p>
-<p>Functionality inspired by <a href="https://pqrs.org/osx/ShowyEdge/index.html.en">ShowyEdge</a></p>
+<p>Functionality inspired by <a href="https://showyedge.pqrs.org/">ShowyEdge</a></p>
 
       </header>
       <h3>API Overview</h3>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7918,7 +7918,7 @@
       }
     ],
     "desc": "Color the menubar according to the current keyboard layout",
-    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
+    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
     "items": [
       {
         "def": "MenubarFlag.allScreens",
@@ -8093,7 +8093,7 @@
       }
     ],
     "name": "MenubarFlag",
-    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
+    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
     "submodules": [],
     "type": "Module"
   },

--- a/docs/templated_docs.json
+++ b/docs/templated_docs.json
@@ -9671,8 +9671,8 @@
     ],
     "desc": "Color the menubar according to the current keyboard layout",
     "desc_gfm": "<p>Color the menubar according to the current keyboard layout</p>\n",
-    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
-    "doc_gfm": "<p>Color the menubar according to the current keyboard layout</p>\n<p>Download: <a href=\"https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip\">https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip</a></p>\n<p>Functionality inspired by <a href=\"https://pqrs.org/osx/ShowyEdge/index.html.en\">ShowyEdge</a></p>\n",
+    "doc": "Color the menubar according to the current keyboard layout\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
+    "doc_gfm": "<p>Color the menubar according to the current keyboard layout</p>\n<p>Download: <a href=\"https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip\">https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip</a></p>\n<p>Functionality inspired by <a href=\"https://showyedge.pqrs.org/\">ShowyEdge</a></p>\n",
     "items": [
       {
         "def": "MenubarFlag.allScreens",
@@ -9881,7 +9881,7 @@
       }
     ],
     "name": "MenubarFlag",
-    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://pqrs.org/osx/ShowyEdge/index.html.en)",
+    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/MenubarFlag.spoon.zip)\n\nFunctionality inspired by [ShowyEdge](https://showyedge.pqrs.org/)",
     "submodules": [],
     "type": "Module"
   },


### PR DESCRIPTION
The old address ( https://pqrs.org/osx/ShowyEdge/index.html.en ) lead to a 404 page not found error