### PR TITLE
Make AClock recalculate canvas on screen change

### DIFF
--- a/Source/AClock.spoon/init.lua
+++ b/Source/AClock.spoon/init.lua
@@ -60,6 +60,17 @@ for k, v in pairs(obj._attribs) do obj[k] = v end
 ---
 --- Returns:
 ---  * The AClock object
+function getframe(width, height)
+    local mainScreen = hs.screen.primaryScreen()
+    local mainRes = mainScreen:fullFrame()
+    return {
+        x = (mainRes.w - width) / 2,
+        y = (mainRes.h - height) / 2,
+        w = width,
+        h = height
+    }
+end
+
 function obj:init()
   if not self.canvas then self.canvas = hs.canvas.new({x=0, y=0, w=0, h=0}) end
   self.canvas[1] = {
@@ -72,14 +83,17 @@ function obj:init()
   }
   local mainScreen = hs.screen.primaryScreen()
   local mainRes = mainScreen:fullFrame()
-  self.canvas:frame({
-    x = (mainRes.w-self.width)/2,
-    y = (mainRes.h-self.height)/2,
-    w = self.width,
-    h = self.height,
-  })
+  self.canvas:frame(getframe(self.width, self.height))
+  self._screen_watcher = hs.screen.watcher.new(function()
+      self:update_canvas()
+  end)
+  self._screen_watcher:start()
   self._init_done = true
   return self
+end
+
+function obj:update_canvas()
+    self.canvas:frame(getframe(self.width, self.height))
 end
 
 function obj:update_clock_text()


### PR DESCRIPTION
AClock tries to display the clock in the center of the screen, but if monitors are plugged in, or the resolution changes, this calculation is no longer correct.

This PR adds a screen watcher to recalculate the frame when the displays change.