### PR TITLE
Improve MicMute spoon by optionally displaying an icon.

### DIFF
--- a/Source/MicMute.spoon/init.lua
+++ b/Source/MicMute.spoon/init.lua
@@ -14,14 +14,47 @@ obj.author = "dctucker <dctucker@github.com>"
 obj.homepage = "https://dctucker.com"
 obj.license = "MIT - https://opensource.org/licenses/MIT"
 
+-- User configuration
+
+-- MicMute.display_mode
+-- Variable
+-- One of: 'text', 'icon', 'both'. It indicates if a text and/or an icon will be shown in the menubar.
+obj.display_mode = 'text'
+
+-- MicMute.title_on
+-- Variable
+-- The text that will be displayed in the menubar when the microphone is on and MicMute.display_mode is either 'text' or 'both'.
+obj.title_on  = "🎙 On"
+
+-- MicMute.title_off
+-- Variable
+-- The text that will be displayed in the menubar when the microphone is off and MicMute.display_mode is either 'text' or 'both'.
+obj.title_off = "📵 Muted"
+
+-- MicMute.icon_on
+-- Variable
+-- The icon that will be displayed in the menubar when the microphone is on and MicMute.display_mode is either 'icon' or 'both'.
+obj.icon_on = hs.image.imageFromName('NSTouchBarAudioInputTemplate')
+
+-- MicMute.icon_off
+-- Variable
+-- The icon that will be displayed in the menubar when the microphone is off and MicMute.display_mode is either 'icon' or 'both'.
+obj.icon_off = hs.image.imageFromName('NSTouchBarAudioInputMuteTemplate')
+
+obj.__displayText = obj.display_mode == 'text' or obj.display_mode == 'both'
+obj.__displayIcon = obj.display_mode == 'icon' or obj.display_mode == 'both'
+
+
 function obj:updateMicMute(muted)
 	if muted == -1 then
 		muted = hs.audiodevice.defaultInputDevice():muted()
 	end
 	if muted then
-		obj.mute_menu:setTitle("📵 Muted")
+		if self.__displayIcon then; obj.mute_menu:setIcon(obj.icon_off); end
+		if self.__displayText then; obj.mute_menu:setTitle(obj.title_off); end
 	else
-		obj.mute_menu:setTitle("🎙 On")
+		if self.__displayIcon then; obj.mute_menu:setIcon(obj.icon_on); end
+		if self.__displayText then; obj.mute_menu:setTitle(obj.title_on); end
 	end
 end
 


### PR DESCRIPTION
This patch adds the possibility to display an icon in the menubar. The default behaviour of the spoon is not changed. The icon display can be activated with the new configuration `display_mode`.

Also, the menubar text can be customised by the user, with the new configurations `title_on` and `title_off`.