### PR TITLE
Improve seal filesearch plugin

### DIFF
--- a/Source/Seal.spoon/seal_filesearch.lua
+++ b/Source/Seal.spoon/seal_filesearch.lua
@@ -128,7 +128,9 @@ end
 function SpotlightFileSearch:buildSpotlightQuery()
     local queryWords = hs.fnutils.split(self.query, "%s+")
     local searchFilters = hs.fnutils.map(queryWords, function(word)
-        return [[kMDItemFSName like[c] "*]] .. word .. [[*"]]
+        -- [c] means case-insensitive
+        -- [d] means don't care about accents (diacritic)
+        return [[kMDItemFSName like[cd] "*]] .. word .. [[*"]]
     end)
     local spotlightQuery = table.concat(searchFilters, [[ && ]])
     return spotlightQuery


### PR DESCRIPTION
This PR contains several improvements for the Seal filesearch plugin:

  - fix a race condition that could lead to some search results not being displayed in certain conditions
  - improve responsiveness by reducing the number of time spotlight search is called
  - improve the ranking of results that contains the exact words of the search query
  - better handle the accent so you get results with/without accents