### PR TITLE
Issue #311  - Fixed Keychain addItem 

### DIFF
--- a/Source/Keychain.spoon/init.lua
+++ b/Source/Keychain.spoon/init.lua
@@ -150,7 +150,7 @@ end
 ---   * comment - comment 
 ---   * label - label (defaults to service name)
 ---   * service - service name (required)
-function obj:addPassword(options)
+function obj:addItem(options)
   
   local cmd="/usr/bin/security add-generic-password"
 
@@ -160,7 +160,6 @@ function obj:addPassword(options)
     end
   end
 
-  cmd = cmd .. "-w " .. options.password 
   local handle = io.popen(cmd)
   local result = handle:read("*a")
  


### PR DESCRIPTION
Issue #311  - Keychain method not called addItem and adds “-w” to service 

Renamed `addPassword` back to `addItem `
Removed the  concatenation of the `cmd` string that added the password string and flag a second time. 
At the same time removing the issue of the missing space which was malforming other options.
The function now works as per the documentation.