### PR TITLE
Fixed an isssue where seal_useractions with query placeholders were not working correctly.

### DIFF
--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -255,7 +255,7 @@ function obj.completionCallback(row)
       local fn = obj.all_actions[row.text].fn
       fn()
    elseif row.type == 'openURL' then
-      local url = string.gsub(obj.all_actions[row.text].url, '${query}', defaultQuery)
+      local url = string.gsub(obj.all_actions[row.text].url, '${query}', "")
       obj.openURL(url)
    elseif row.type == 'addURL' then
       obj.stored_actions[row.name] = { url = row.url }

--- a/Source/Seal.spoon/seal_useractions.lua
+++ b/Source/Seal.spoon/seal_useractions.lua
@@ -255,7 +255,7 @@ function obj.completionCallback(row)
       local fn = obj.all_actions[row.text].fn
       fn()
    elseif row.type == 'openURL' then
-      local url = obj.all_actions[row.text].url
+      local url = string.gsub(obj.all_actions[row.text].url, '${query}', defaultQuery)
       obj.openURL(url)
    elseif row.type == 'addURL' then
       obj.stored_actions[row.name] = { url = row.url }


### PR DESCRIPTION
When choosing an URL without providing parameters, it would open as if the ${query} parameter was entered.